### PR TITLE
Documentation Reporter Identation and Small Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   <dependencies>
     <dependency>
       <groupId>com.oracle.jdbc</groupId>
-      <artifactId>ojdbc7</artifactId>
-      <version>12.1.0.2</version>
+      <artifactId>ojdbc8</artifactId>
+      <version>12.2.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/github/utplsql/api/TestRunner.java
+++ b/src/main/java/io/github/utplsql/api/TestRunner.java
@@ -15,6 +15,7 @@ public class TestRunner {
 
     private List<String> pathList = new ArrayList<>();
     private List<Reporter> reporterList = new ArrayList<>();
+    private boolean colorConsole = false;
     private List<String> coverageSchemes = new ArrayList<>();
     private List<String> sourceFiles = new ArrayList<>();
     private List<String> testFiles = new ArrayList<>();
@@ -33,6 +34,11 @@ public class TestRunner {
 
     public TestRunner addReporter(Reporter reporter) {
         this.reporterList.add(reporter);
+        return this;
+    }
+
+    public TestRunner colorConsole(boolean colorConsole) {
+        this.colorConsole = colorConsole;
         return this;
     }
 
@@ -87,13 +93,16 @@ public class TestRunner {
         Array includeObjectsArray = oraConn.createARRAY(CustomTypes.UT_VARCHAR2_LIST, this.includeObjects.toArray());
         Array excludeObjectsArray = oraConn.createARRAY(CustomTypes.UT_VARCHAR2_LIST, this.excludeObjects.toArray());
 
+        // Workaround because Oracle JDBC doesn't support passing boolean to stored procedures.
+        String colorConsoleStr = Boolean.toString(this.colorConsole);
+
         CallableStatement callableStatement = null;
         try {
             callableStatement = conn.prepareCall(
                     "BEGIN " +
                         "ut_runner.run(" +
-                            "a_paths => ?, a_reporters => ?, a_coverage_schemes => ?," +
-                            "a_source_files => ?, a_test_files => ?, " +
+                            "a_paths => ?, a_reporters => ?, a_color_console => " + colorConsoleStr + ", " +
+                            "a_coverage_schemes => ?, a_source_files => ?, a_test_files => ?, " +
                             "a_include_objects => ?, a_exclude_objects => ?); " +
                     "END;");
             callableStatement.setArray(1, pathArray);

--- a/src/main/java/io/github/utplsql/api/reporter/DocumentationReporter.java
+++ b/src/main/java/io/github/utplsql/api/reporter/DocumentationReporter.java
@@ -3,12 +3,52 @@ package io.github.utplsql.api.reporter;
 import io.github.utplsql.api.CustomTypes;
 
 import java.sql.SQLException;
+import java.sql.SQLInput;
+import java.sql.SQLOutput;
 
 public class DocumentationReporter extends Reporter {
+
+    private int lvl;
+    private int failed;
+
+    public DocumentationReporter() {
+        this.lvl = 0;
+        this.failed = 0;
+    }
+
+    public int getLvl() {
+        return lvl;
+    }
+
+    public void setLvl(int lvl) {
+        this.lvl = lvl;
+    }
+
+    public int getFailed() {
+        return failed;
+    }
+
+    public void setFailed(int failed) {
+        this.failed = failed;
+    }
 
     @Override
     public String getSQLTypeName() throws SQLException {
         return CustomTypes.UT_DOCUMENTATION_REPORTER;
+    }
+
+    @Override
+    public void readSQL(SQLInput stream, String typeName) throws SQLException {
+        super.readSQL(stream, typeName);
+        setLvl(stream.readInt());
+        setFailed(stream.readInt());
+    }
+
+    @Override
+    public void writeSQL(SQLOutput stream) throws SQLException {
+        super.writeSQL(stream);
+        stream.writeInt(getLvl());
+        stream.writeInt(getFailed());
     }
 
 }

--- a/src/main/java/io/github/utplsql/api/reporter/Reporter.java
+++ b/src/main/java/io/github/utplsql/api/reporter/Reporter.java
@@ -17,6 +17,7 @@ public abstract class Reporter implements SQLData {
     public Reporter() {}
 
     public Reporter init(Connection conn) throws SQLException {
+        setSelfType(getSQLTypeName());
         setStartDate(new java.sql.Date(Calendar.getInstance().getTimeInMillis()));
         setReporterId(DBHelper.newSysGuid(conn));
         return this;


### PR DESCRIPTION
* Fixes identation on documentation reporter. This one was tricky, the lvl variable on ut_documentation_reporter was null because the constructor is not being called on java, hence identation was not working.
* Add suport for console colors.
* Updated ojdbc version to 8.