### PR TITLE
Add custom file mapping support

### DIFF
--- a/src/main/java/io/github/utplsql/api/CustomTypes.java
+++ b/src/main/java/io/github/utplsql/api/CustomTypes.java
@@ -5,7 +5,10 @@ package io.github.utplsql.api;
  */
 public final class CustomTypes {
 
-    // Object names must be upper case.
+    /* Object names must be upper case. */
+
+    public static final String UT_VARCHAR2_LIST = "UT_VARCHAR2_LIST";
+
     public static final String UT_REPORTERS = "UT_REPORTERS";
     public static final String UT_DOCUMENTATION_REPORTER = "UT_DOCUMENTATION_REPORTER";
     public static final String UT_COVERAGE_HTML_REPORTER = "UT_COVERAGE_HTML_REPORTER";
@@ -14,7 +17,12 @@ public final class CustomTypes {
     public static final String UT_COVERALLS_REPORTER = "UT_COVERALLS_REPORTER";
     public static final String UT_COVERAGE_SONAR_REPORTER = "UT_COVERAGE_SONAR_REPORTER";
     public static final String UT_SONAR_TEST_REPORTER = "UT_SONAR_TEST_REPORTER";
-    public static final String UT_VARCHAR2_LIST = "UT_VARCHAR2_LIST";
+
+    public static final String UT_FILE_MAPPING = "UT_FILE_MAPPING";
+    public static final String UT_FILE_MAPPINGS = "UT_FILE_MAPPINGS";
+
+    public static final String UT_KEY_VALUE_PAIR = "UT_KEY_VALUE_PAIR";
+    public static final String UT_KEY_VALUE_PAIRS = "UT_KEY_VALUE_PAIRS";
 
     private CustomTypes() {}
 

--- a/src/main/java/io/github/utplsql/api/FileMapper.java
+++ b/src/main/java/io/github/utplsql/api/FileMapper.java
@@ -43,7 +43,7 @@ public final class FileMapper {
         int paramIdx = 0;
         callableStatement.registerOutParameter(++paramIdx, OracleTypes.ARRAY, CustomTypes.UT_FILE_MAPPINGS);
 
-        callableStatement.setString(++paramIdx, mapperOptions.getOwner());
+        callableStatement.setString(++paramIdx, mapperOptions.getObjectOwner());
         callableStatement.setArray(
                 ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, filePaths.toArray()));
         callableStatement.setArray(

--- a/src/main/java/io/github/utplsql/api/FileMapper.java
+++ b/src/main/java/io/github/utplsql/api/FileMapper.java
@@ -1,0 +1,70 @@
+package io.github.utplsql.api;
+
+
+import oracle.jdbc.OracleConnection;
+import oracle.jdbc.OracleTypes;
+
+import java.sql.Array;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public final class FileMapper {
+
+    private FileMapper() {}
+
+    /**
+     * Call the database api to build the custom file mappings.
+     */
+    public static Array buildFileMappingArray(Connection conn, FileMapperOptions mapperOptions) throws SQLException {
+        OracleConnection oraConn = conn.unwrap(OracleConnection.class);
+
+        Map typeMap = conn.getTypeMap();
+        typeMap.put(CustomTypes.UT_FILE_MAPPING, FileMapping.class);
+        typeMap.put(CustomTypes.UT_KEY_VALUE_PAIR, KeyValuePair.class);
+        conn.setTypeMap(typeMap);
+
+        CallableStatement callableStatement = conn.prepareCall(
+                "BEGIN " +
+                    "? := ut_file_mapper.build_file_mappings(" +
+                        "a_object_owner                => ?, " +
+                        "a_file_paths                  => ?, " +
+                        "a_file_to_object_type_mapping => ?, " +
+                        "a_regex_pattern               => ?, " +
+                        "a_object_owner_subexpression  => ?, " +
+                        "a_object_name_subexpression   => ?, " +
+                        "a_object_type_subexpression   => ?); " +
+                "END;");
+
+        int paramIdx = 0;
+        callableStatement.registerOutParameter(++paramIdx, OracleTypes.ARRAY, CustomTypes.UT_FILE_MAPPINGS);
+
+        callableStatement.setString(++paramIdx, mapperOptions.getOwner());
+        callableStatement.setArray(
+                ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, mapperOptions.getFilePaths().toArray()));
+        callableStatement.setArray(
+                ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_KEY_VALUE_PAIRS, mapperOptions.getTypeMappings().toArray()));
+        callableStatement.setString(++paramIdx, mapperOptions.getRegexPattern());
+        callableStatement.setInt(++paramIdx, mapperOptions.getOwnerSubExpression());
+        callableStatement.setInt(++paramIdx, mapperOptions.getNameSubExpression());
+        callableStatement.setInt(++paramIdx, mapperOptions.getTypeSubExpression());
+
+        callableStatement.execute();
+        return callableStatement.getArray(1);
+    }
+
+    public static List<FileMapping> buildFileMappingList(Connection conn, FileMapperOptions mapperOptions) throws SQLException {
+        java.sql.Array fileMappings = buildFileMappingArray(conn, mapperOptions);
+
+        List<FileMapping> mappingList = new ArrayList<>();
+        for (Object obj : (Object[]) fileMappings.getArray()) {
+            mappingList.add((FileMapping) obj);
+        }
+
+        return mappingList;
+    }
+
+}

--- a/src/main/java/io/github/utplsql/api/FileMapper.java
+++ b/src/main/java/io/github/utplsql/api/FileMapper.java
@@ -19,7 +19,8 @@ public final class FileMapper {
     /**
      * Call the database api to build the custom file mappings.
      */
-    public static Array buildFileMappingArray(Connection conn, FileMapperOptions mapperOptions) throws SQLException {
+    public static Array buildFileMappingArray(
+            Connection conn, List<String> filePaths, FileMapperOptions mapperOptions) throws SQLException {
         OracleConnection oraConn = conn.unwrap(OracleConnection.class);
 
         Map typeMap = conn.getTypeMap();
@@ -44,7 +45,7 @@ public final class FileMapper {
 
         callableStatement.setString(++paramIdx, mapperOptions.getOwner());
         callableStatement.setArray(
-                ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, mapperOptions.getFilePaths().toArray()));
+                ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, filePaths.toArray()));
         callableStatement.setArray(
                 ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_KEY_VALUE_PAIRS, mapperOptions.getTypeMappings().toArray()));
         callableStatement.setString(++paramIdx, mapperOptions.getRegexPattern());
@@ -56,8 +57,9 @@ public final class FileMapper {
         return callableStatement.getArray(1);
     }
 
-    public static List<FileMapping> buildFileMappingList(Connection conn, FileMapperOptions mapperOptions) throws SQLException {
-        java.sql.Array fileMappings = buildFileMappingArray(conn, mapperOptions);
+    public static List<FileMapping> buildFileMappingList(
+            Connection conn, List<String> filePaths, FileMapperOptions mapperOptions) throws SQLException {
+        java.sql.Array fileMappings = buildFileMappingArray(conn, filePaths, mapperOptions);
 
         List<FileMapping> mappingList = new ArrayList<>();
         for (Object obj : (Object[]) fileMappings.getArray()) {

--- a/src/main/java/io/github/utplsql/api/FileMapperOptions.java
+++ b/src/main/java/io/github/utplsql/api/FileMapperOptions.java
@@ -1,0 +1,77 @@
+package io.github.utplsql.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileMapperOptions {
+
+    private String owner;
+    private List<String> filePaths;
+    private List<KeyValuePair> typeMappings;
+    private String regexPattern;
+    private int ownerSubExpression;
+    private int typeSubExpression;
+    private int nameSubExpression;
+
+    public FileMapperOptions() {
+        this.filePaths = new ArrayList<>();
+        this.typeMappings = new ArrayList<>();
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public List<String> getFilePaths() {
+        return filePaths;
+    }
+
+    public void setFilePaths(List<String> filePaths) {
+        this.filePaths = filePaths;
+    }
+
+    public List<KeyValuePair> getTypeMappings() {
+        return typeMappings;
+    }
+
+    public void setTypeMappings(List<KeyValuePair> typeMappings) {
+        this.typeMappings = typeMappings;
+    }
+
+    public String getRegexPattern() {
+        return regexPattern;
+    }
+
+    public void setRegexPattern(String regexPattern) {
+        this.regexPattern = regexPattern;
+    }
+
+    public int getOwnerSubExpression() {
+        return ownerSubExpression;
+    }
+
+    public void setOwnerSubExpression(int ownerSubExpression) {
+        this.ownerSubExpression = ownerSubExpression;
+    }
+
+    public int getTypeSubExpression() {
+        return typeSubExpression;
+    }
+
+    public void setTypeSubExpression(int typeSubExpression) {
+        this.typeSubExpression = typeSubExpression;
+    }
+
+    public int getNameSubExpression() {
+        return nameSubExpression;
+    }
+
+    public void setNameSubExpression(int nameSubExpression) {
+        this.nameSubExpression = nameSubExpression;
+    }
+
+}

--- a/src/main/java/io/github/utplsql/api/FileMapperOptions.java
+++ b/src/main/java/io/github/utplsql/api/FileMapperOptions.java
@@ -6,15 +6,13 @@ import java.util.List;
 public class FileMapperOptions {
 
     private String owner;
-    private List<String> filePaths;
     private List<KeyValuePair> typeMappings;
     private String regexPattern;
     private int ownerSubExpression;
     private int typeSubExpression;
     private int nameSubExpression;
 
-    public FileMapperOptions() {
-        this.filePaths = new ArrayList<>();
+    public FileMapperOptions(List<String> filePaths) {
         this.typeMappings = new ArrayList<>();
     }
 
@@ -24,14 +22,6 @@ public class FileMapperOptions {
 
     public void setOwner(String owner) {
         this.owner = owner;
-    }
-
-    public List<String> getFilePaths() {
-        return filePaths;
-    }
-
-    public void setFilePaths(List<String> filePaths) {
-        this.filePaths = filePaths;
     }
 
     public List<KeyValuePair> getTypeMappings() {

--- a/src/main/java/io/github/utplsql/api/FileMapperOptions.java
+++ b/src/main/java/io/github/utplsql/api/FileMapperOptions.java
@@ -5,23 +5,23 @@ import java.util.List;
 
 public class FileMapperOptions {
 
-    private String owner;
+    private String objectOwner;
     private List<KeyValuePair> typeMappings;
     private String regexPattern;
     private int ownerSubExpression;
     private int typeSubExpression;
     private int nameSubExpression;
 
-    public FileMapperOptions(List<String> filePaths) {
+    public FileMapperOptions() {
         this.typeMappings = new ArrayList<>();
     }
 
-    public String getOwner() {
-        return owner;
+    public String getObjectOwner() {
+        return objectOwner;
     }
 
-    public void setOwner(String owner) {
-        this.owner = owner;
+    public void setObjectOwner(String owner) {
+        this.objectOwner = owner;
     }
 
     public List<KeyValuePair> getTypeMappings() {

--- a/src/main/java/io/github/utplsql/api/FileMapping.java
+++ b/src/main/java/io/github/utplsql/api/FileMapping.java
@@ -1,0 +1,78 @@
+package io.github.utplsql.api;
+
+import java.sql.SQLData;
+import java.sql.SQLException;
+import java.sql.SQLInput;
+import java.sql.SQLOutput;
+
+/**
+ * Created by Vinicius on 17/07/2017.
+ */
+public class FileMapping implements SQLData {
+
+    private String fileName;
+    private String objectOwner;
+    private String objectName;
+    private String objectType;
+
+    public FileMapping() {}
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getObjectOwner() {
+        return objectOwner;
+    }
+
+    public void setObjectOwner(String objectOwner) {
+        this.objectOwner = objectOwner;
+    }
+
+    public String getObjectName() {
+        return objectName;
+    }
+
+    public void setObjectName(String objectName) {
+        this.objectName = objectName;
+    }
+
+    public String getObjectType() {
+        return objectType;
+    }
+
+    public void setObjectType(String objectType) {
+        this.objectType = objectType;
+    }
+
+    @Override
+    public String getSQLTypeName() throws SQLException {
+        return CustomTypes.UT_FILE_MAPPING;
+    }
+
+    @Override
+    public void readSQL(SQLInput stream, String typeName) throws SQLException {
+        setFileName(stream.readString());
+        setObjectOwner(stream.readString());
+        setObjectName(stream.readString());
+        setObjectType(stream.readString());
+    }
+
+    @Override
+    public void writeSQL(SQLOutput stream) throws SQLException {
+        stream.writeString(getFileName());
+        stream.writeString(getObjectOwner());
+        stream.writeString(getObjectName());
+        stream.writeString(getObjectType());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s/%s.%s", getObjectType(), getObjectOwner(), getObjectName());
+    }
+
+}

--- a/src/main/java/io/github/utplsql/api/KeyValuePair.java
+++ b/src/main/java/io/github/utplsql/api/KeyValuePair.java
@@ -1,0 +1,59 @@
+package io.github.utplsql.api;
+
+import java.sql.SQLData;
+import java.sql.SQLException;
+import java.sql.SQLInput;
+import java.sql.SQLOutput;
+
+/**
+ * Created by Vinicius on 22/07/2017.
+ */
+public class KeyValuePair implements SQLData {
+
+    private String key;
+    private String value;
+
+    public KeyValuePair(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getSQLTypeName() throws SQLException {
+        return CustomTypes.UT_KEY_VALUE_PAIR;
+    }
+
+    @Override
+    public void readSQL(SQLInput stream, String typeName) throws SQLException {
+        setKey(stream.readString());
+        setValue(stream.readString());
+    }
+
+    @Override
+    public void writeSQL(SQLOutput stream) throws SQLException {
+        stream.writeString(getKey());
+        stream.writeString(getValue());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s => %s", getKey(), getValue());
+    }
+
+}

--- a/src/main/java/io/github/utplsql/api/TestRunner.java
+++ b/src/main/java/io/github/utplsql/api/TestRunner.java
@@ -100,7 +100,7 @@ public class TestRunner {
         try {
             callableStatement = conn.prepareCall(
                     "BEGIN " +
-                            "ut_runner.run(" +
+                        "ut_runner.run(" +
                             "a_paths            => ?, " +
                             "a_reporters        => ?, " +
                             "a_color_console    => " + colorConsoleStr + ", " +
@@ -110,49 +110,49 @@ public class TestRunner {
                             "a_include_objects  => ?, " +
                             "a_exclude_objects  => ?, " +
                             "a_fail_on_errors   => " + failOnErrors + "); " +
-                            "END;");
+                    "END;");
 
             int paramIdx = 0;
 
             callableStatement.setArray(
-                    ++paramIdx, oraConn.createARRAY(CustomTypes.UT_VARCHAR2_LIST, this.pathList.toArray()));
+                    ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, this.pathList.toArray()));
 
             callableStatement.setArray(
-                    ++paramIdx, oraConn.createARRAY(CustomTypes.UT_REPORTERS, this.reporterList.toArray()));
+                    ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_REPORTERS, this.reporterList.toArray()));
 
             if (this.coverageSchemes.isEmpty()) {
                 callableStatement.setNull(++paramIdx, Types.ARRAY, CustomTypes.UT_VARCHAR2_LIST);
             } else {
                 callableStatement.setArray(
-                        ++paramIdx, oraConn.createARRAY(CustomTypes.UT_VARCHAR2_LIST, this.coverageSchemes.toArray()));
+                        ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, this.coverageSchemes.toArray()));
             }
 
             if (this.sourceFiles.isEmpty()) {
                 callableStatement.setNull(++paramIdx, Types.ARRAY, CustomTypes.UT_VARCHAR2_LIST);
             } else {
                 callableStatement.setArray(
-                        ++paramIdx, oraConn.createARRAY(CustomTypes.UT_VARCHAR2_LIST, this.sourceFiles.toArray()));
+                        ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, this.sourceFiles.toArray()));
             }
 
             if (this.testFiles.isEmpty()) {
                 callableStatement.setNull(++paramIdx, Types.ARRAY, CustomTypes.UT_VARCHAR2_LIST);
             } else {
                 callableStatement.setArray(
-                        ++paramIdx, oraConn.createARRAY(CustomTypes.UT_VARCHAR2_LIST, this.testFiles.toArray()));
+                        ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, this.testFiles.toArray()));
             }
 
             if (this.includeObjects.isEmpty()) {
                 callableStatement.setNull(++paramIdx, Types.ARRAY, CustomTypes.UT_VARCHAR2_LIST);
             } else {
                 callableStatement.setArray(
-                        ++paramIdx, oraConn.createARRAY(CustomTypes.UT_VARCHAR2_LIST, this.includeObjects.toArray()));
+                        ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, this.includeObjects.toArray()));
             }
 
             if (this.excludeObjects.isEmpty()) {
                 callableStatement.setNull(++paramIdx, Types.ARRAY, CustomTypes.UT_VARCHAR2_LIST);
             } else {
                 callableStatement.setArray(
-                        ++paramIdx, oraConn.createARRAY(CustomTypes.UT_VARCHAR2_LIST, this.excludeObjects.toArray()));
+                        ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, this.excludeObjects.toArray()));
             }
 
             callableStatement.execute();

--- a/src/test/java/io/github/utplsql/api/FileMapperTest.java
+++ b/src/test/java/io/github/utplsql/api/FileMapperTest.java
@@ -1,0 +1,49 @@
+package io.github.utplsql.api;
+
+import io.github.utplsql.api.rules.DatabaseRule;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileMapperTest {
+
+    @Rule
+    public final DatabaseRule db = new DatabaseRule();
+
+    @Test
+    public void testFileMapper() throws SQLException {
+        List<KeyValuePair> typeMappings = new ArrayList<>();
+        typeMappings.add(new KeyValuePair("procedures", "PROCEDURE"));
+        typeMappings.add(new KeyValuePair("functions", "FUNCTION"));
+
+        FileMapperOptions mapperOptions = new FileMapperOptions();
+        mapperOptions.setOwner("APP");
+        mapperOptions.setFilePaths(java.util.Arrays.asList(
+                "sources/app/procedures/award_bonus.sql",
+                "sources/app/functions/betwnstr.sql"));
+        mapperOptions.setTypeMappings(typeMappings);
+        mapperOptions.setRegexPattern("\\w+[\\\\\\/](\\w+)[\\\\\\/](\\w+)[\\\\\\/](\\w+)[.](\\w{3})");
+        mapperOptions.setOwnerSubExpression(1);
+        mapperOptions.setTypeSubExpression(2);
+        mapperOptions.setNameSubExpression(3);
+
+        List<FileMapping> fileMappings = FileMapper.buildFileMappingList(db.newConnection(), mapperOptions);
+
+        if (fileMappings.size() != 2)
+            Assert.fail("Wrong mapping list size.");
+
+        assertMapping(fileMappings.get(0), "APP", "AWARD_BONUS", "PROCEDURE");
+        assertMapping(fileMappings.get(1), "APP", "BETWNSTR", "FUNCTION");
+    }
+
+    private void assertMapping(FileMapping fileMapping, String owner, String name, String type) {
+        Assert.assertEquals(owner, fileMapping.getObjectOwner());
+        Assert.assertEquals(name, fileMapping.getObjectName());
+        Assert.assertEquals(type, fileMapping.getObjectType());
+    }
+
+}

--- a/src/test/java/io/github/utplsql/api/FileMapperTest.java
+++ b/src/test/java/io/github/utplsql/api/FileMapperTest.java
@@ -24,8 +24,8 @@ public class FileMapperTest {
                 "sources/app/procedures/award_bonus.sql",
                 "sources/app/functions/betwnstr.sql");
 
-        FileMapperOptions mapperOptions = new FileMapperOptions(filePaths);
-        mapperOptions.setOwner("APP");
+        FileMapperOptions mapperOptions = new FileMapperOptions();
+        mapperOptions.setObjectOwner("APP");
         mapperOptions.setTypeMappings(typeMappings);
         mapperOptions.setRegexPattern("\\w+[\\\\\\/](\\w+)[\\\\\\/](\\w+)[\\\\\\/](\\w+)[.](\\w{3})");
         mapperOptions.setOwnerSubExpression(1);

--- a/src/test/java/io/github/utplsql/api/FileMapperTest.java
+++ b/src/test/java/io/github/utplsql/api/FileMapperTest.java
@@ -20,18 +20,19 @@ public class FileMapperTest {
         typeMappings.add(new KeyValuePair("procedures", "PROCEDURE"));
         typeMappings.add(new KeyValuePair("functions", "FUNCTION"));
 
-        FileMapperOptions mapperOptions = new FileMapperOptions();
-        mapperOptions.setOwner("APP");
-        mapperOptions.setFilePaths(java.util.Arrays.asList(
+        List<String> filePaths = java.util.Arrays.asList(
                 "sources/app/procedures/award_bonus.sql",
-                "sources/app/functions/betwnstr.sql"));
+                "sources/app/functions/betwnstr.sql");
+
+        FileMapperOptions mapperOptions = new FileMapperOptions(filePaths);
+        mapperOptions.setOwner("APP");
         mapperOptions.setTypeMappings(typeMappings);
         mapperOptions.setRegexPattern("\\w+[\\\\\\/](\\w+)[\\\\\\/](\\w+)[\\\\\\/](\\w+)[.](\\w{3})");
         mapperOptions.setOwnerSubExpression(1);
         mapperOptions.setTypeSubExpression(2);
         mapperOptions.setNameSubExpression(3);
 
-        List<FileMapping> fileMappings = FileMapper.buildFileMappingList(db.newConnection(), mapperOptions);
+        List<FileMapping> fileMappings = FileMapper.buildFileMappingList(db.newConnection(), filePaths, mapperOptions);
 
         if (fileMappings.size() != 2)
             Assert.fail("Wrong mapping list size.");


### PR DESCRIPTION
Added support for custom file mappings on the java api/client. I think it's working, but need some improvements.

One thing I noticed is the ut_file_mapper use default values on the function declaration, and because of that, if I want to use default parameters when user pass null values, I need to:
- build different sql queries
- or get default values from database before calling the build_file_mappings

For now, custom mapping only works if you pass all parameters.