### PR TITLE
Close reporters if any unexpected errors occurred while running tests

### DIFF
--- a/src/main/java/org/utplsql/api/TestRunner.java
+++ b/src/main/java/org/utplsql/api/TestRunner.java
@@ -171,6 +171,13 @@ public class TestRunner {
             if (e.getErrorCode() == SomeTestsFailedException.ERROR_CODE) {
                 throw new SomeTestsFailedException(e.getMessage(), e);
             } else {
+                // If the execution failed by unexpected reasons finishes all reporters,
+                // this way the users don't need to care about reporters' sessions hanging.
+                try (CallableStatement closeBufferStmt = conn.prepareCall("BEGIN ut_output_buffer.close(?); END;")) {
+                    closeBufferStmt.setArray(1, oraConn.createOracleArray(CustomTypes.UT_REPORTERS, this.reporterList.toArray()));
+                    closeBufferStmt.execute();
+                } catch (SQLException ignored) {}
+
                 throw e;
             }
         } finally {


### PR DESCRIPTION
Trying to fix the problem with hanging sessions when an error occurs during the tests execution.
https://github.com/utPLSQL/utPLSQL-cli/issues/35