### PR TITLE
Bugfix/immediate feedback output buffer

### DIFF
--- a/src/main/java/org/utplsql/api/outputBuffer/CompatibilityOutputBufferPre310.java
+++ b/src/main/java/org/utplsql/api/outputBuffer/CompatibilityOutputBufferPre310.java
@@ -5,7 +5,6 @@ import org.utplsql.api.reporter.Reporter;
 
 import java.sql.CallableStatement;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 /** Compatibility Output-Buffer for 3.0.0 - 3.0.4
@@ -16,13 +15,6 @@ class CompatibilityOutputBufferPre310 extends AbstractOutputBuffer {
 
     CompatibilityOutputBufferPre310( Reporter reporter ) {
         super(reporter);
-    }
-
-    @Override
-    protected PreparedStatement getLinesStatement(Connection conn) throws SQLException {
-        PreparedStatement pstmt = conn.prepareStatement("SELECT * FROM table(ut_output_buffer.get_lines(?))");
-        pstmt.setString(1, getReporter().getId());
-        return pstmt;
     }
 
     @Override

--- a/src/main/java/org/utplsql/api/outputBuffer/DefaultOutputBuffer.java
+++ b/src/main/java/org/utplsql/api/outputBuffer/DefaultOutputBuffer.java
@@ -2,16 +2,12 @@ package org.utplsql.api.outputBuffer;
 
 import oracle.jdbc.OracleCallableStatement;
 import oracle.jdbc.OracleConnection;
-import oracle.jdbc.OraclePreparedStatement;
-import org.utplsql.api.reporter.Reporter;
 import oracle.jdbc.OracleTypes;
+import org.utplsql.api.reporter.Reporter;
 
-import javax.xml.transform.Result;
-import java.io.PrintStream;
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 /**
  * Fetches the lines produced by a reporter.
@@ -27,14 +23,6 @@ class DefaultOutputBuffer extends AbstractOutputBuffer {
      */
     DefaultOutputBuffer(Reporter reporter) {
         super(reporter);
-    }
-
-    @Override
-    protected PreparedStatement getLinesStatement(Connection conn) throws SQLException {
-        OracleConnection oraConn = conn.unwrap(OracleConnection.class);
-        OraclePreparedStatement pstmt = (OraclePreparedStatement)oraConn.prepareStatement("select * from table(?.get_lines())");
-        pstmt.setORAData(1, getReporter());
-        return pstmt;
     }
 
     @Override

--- a/src/main/java/org/utplsql/api/reporter/Reporter.java
+++ b/src/main/java/org/utplsql/api/reporter/Reporter.java
@@ -5,8 +5,6 @@ import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleTypes;
 import oracle.sql.Datum;
 import oracle.sql.ORAData;
-import oracle.sql.STRUCT;
-import oracle.sql.StructDescriptor;
 import org.utplsql.api.compatibility.CompatibilityProxy;
 import org.utplsql.api.outputBuffer.OutputBuffer;
 
@@ -103,9 +101,7 @@ public abstract class Reporter implements ORAData {
 
     public Datum toDatum(Connection c) throws SQLException
     {
-        StructDescriptor sd =
-                StructDescriptor.createDescriptor(getTypeName(), c);
-        return new STRUCT(sd, c, getAttributes());
+        return (Datum)c.createStruct(getTypeName(), getAttributes());
     }
 
     public OutputBuffer getOutputBuffer() {

--- a/src/main/java/org/utplsql/api/reporter/ReporterFactory.java
+++ b/src/main/java/org/utplsql/api/reporter/ReporterFactory.java
@@ -3,10 +3,10 @@ package org.utplsql.api.reporter;
 import oracle.sql.Datum;
 import oracle.sql.ORAData;
 import oracle.sql.ORADataFactory;
-import oracle.sql.STRUCT;
 import org.utplsql.api.compatibility.CompatibilityProxy;
 
 import java.sql.SQLException;
+import java.sql.Struct;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -117,9 +117,9 @@ public final class ReporterFactory implements ORADataFactory {
     @Override
     public ORAData create(Datum d, int sqlType) throws SQLException {
         if (d == null) return null;
-        if ( d instanceof STRUCT) {
-            String sqlName = ((STRUCT)d).getDescriptor().getName();
-            return createReporter(sqlName, ((STRUCT)d).getAttributes());
+        if ( d instanceof Struct) {
+            String sqlName = ((Struct)d).getSQLTypeName();
+            return createReporter(sqlName, ((Struct)d).getAttributes());
         }
 
         return null;


### PR DESCRIPTION
For some reason setFetchSize won't work when calling a pipelined object-function. Now we always use the cursor-function to get the reporter-results.

Resolves https://github.com/utPLSQL/utPLSQL-cli/issues/68