### PR TITLE
Feature/pass client charset to xml and html

### DIFF
--- a/src/main/java/org/utplsql/api/TestRunner.java
+++ b/src/main/java/org/utplsql/api/TestRunner.java
@@ -180,4 +180,15 @@ public class TestRunner {
             reporter.init(conn, compatibilityProxy, reporterFactory);
     }
 
+    /** Returns the databaseVersion the TestRunner was run against
+     *
+     * @return Version of the database the TestRunner was run against
+     */
+    public Version getUsedDatabaseVersion() {
+        if ( compatibilityProxy != null )
+            return compatibilityProxy.getDatabaseVersion();
+        else
+            return null;
+    }
+
 }

--- a/src/main/java/org/utplsql/api/TestRunnerOptions.java
+++ b/src/main/java/org/utplsql/api/TestRunnerOptions.java
@@ -2,6 +2,8 @@ package org.utplsql.api;
 
 import org.utplsql.api.reporter.Reporter;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,4 +24,5 @@ public class TestRunnerOptions {
     public FileMapperOptions testMappingOptions;
     public boolean failOnErrors = false;
     public boolean skipCompatibilityCheck = false;
+    public String clientCharacterSet = Charset.defaultCharset().toString();
 }

--- a/src/main/java/org/utplsql/api/testRunner/AbstractTestRunnerStatement.java
+++ b/src/main/java/org/utplsql/api/testRunner/AbstractTestRunnerStatement.java
@@ -30,7 +30,7 @@ abstract class AbstractTestRunnerStatement implements TestRunnerStatement {
 
     protected abstract String getSql();
 
-    protected void createStatement() throws SQLException {
+    protected int createStatement() throws SQLException {
 
         OracleConnection oraConn = conn.unwrap(OracleConnection.class);
 
@@ -82,6 +82,8 @@ abstract class AbstractTestRunnerStatement implements TestRunnerStatement {
             callableStatement.setArray(
                     ++paramIdx, oraConn.createOracleArray(CustomTypes.UT_VARCHAR2_LIST, options.excludeObjects.toArray()));
         }
+
+        return paramIdx;
     }
 
     public void execute() throws SQLException {

--- a/src/main/java/org/utplsql/api/testRunner/Pre312TestRunnerStatement.java
+++ b/src/main/java/org/utplsql/api/testRunner/Pre312TestRunnerStatement.java
@@ -5,14 +5,14 @@ import org.utplsql.api.TestRunnerOptions;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-/** Provides the call to run tests for the most actual Framework version.
- * Includes fail on error
+/** TestRunner-Statement for Framework version before 3.0.3
+ * Does not know about client character set
  *
  * @author  pesse
  */
-class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
+class Pre312TestRunnerStatement extends AbstractTestRunnerStatement {
 
-    public ActualTestRunnerStatement(TestRunnerOptions options, Connection connection ) throws SQLException {
+    public Pre312TestRunnerStatement(TestRunnerOptions options, Connection connection ) throws SQLException {
         super( options, connection);
     }
 
@@ -33,17 +33,7 @@ class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
                         "a_test_file_mappings   => ?, " +
                         "a_include_objects      => ?, " +
                         "a_exclude_objects      => ?, " +
-                        "a_fail_on_errors       => " + failOnErrors + ", " +
-                        "a_client_character_set => ?); " +
+                        "a_fail_on_errors       => " + failOnErrors + "); " +
                         "END;";
-    }
-
-    @Override
-    protected int createStatement() throws SQLException {
-        int curParamIdx = super.createStatement();
-
-        callableStatement.setString(++curParamIdx, options.clientCharacterSet);
-
-        return curParamIdx;
     }
 }

--- a/src/main/java/org/utplsql/api/testRunner/TestRunnerStatementProvider.java
+++ b/src/main/java/org/utplsql/api/testRunner/TestRunnerStatementProvider.java
@@ -29,6 +29,8 @@ public class TestRunnerStatementProvider {
         try {
             if (databaseVersion.isLessThan(new Version("3.0.3")))
                 stmt = new Pre303TestRunnerStatement(options, conn);
+            else if (databaseVersion.isLessThan(new Version("3.1.2")))
+                stmt = new Pre312TestRunnerStatement(options, conn);
 
         } catch ( InvalidVersionException e ) {}
 

--- a/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
+++ b/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
@@ -20,8 +20,20 @@ public class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
 
 
     @Test
-    public void testGettingActualVersion() throws SQLException {
+    public void testGettingPre312Version_from_303() throws SQLException {
         TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(new Version("3.0.3"), new TestRunnerOptions(), getConnection());
+        assertEquals(Pre312TestRunnerStatement.class, stmt.getClass());
+    }
+
+    @Test
+    public void testGettingPre312Version_from_311() throws SQLException {
+        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(new Version("3.1.1"), new TestRunnerOptions(), getConnection());
+        assertEquals(Pre312TestRunnerStatement.class, stmt.getClass());
+    }
+
+    @Test
+    public void testGettingActualVersion() throws SQLException {
+        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(new Version("3.1.2"), new TestRunnerOptions(), getConnection());
         assertEquals(ActualTestRunnerStatement.class, stmt.getClass());
     }
 }


### PR DESCRIPTION
Passes `Charset.defaultCharset()` to ut_runner.run as client encoding.

Requires utPLSQL/utPLSQL#697
Fixes utPLSQL/utPLSQL-cli#78