### PR TITLE
Cleanup base on IDEA Code Inspector and small refactoring

### DIFF
--- a/src/main/java/org/utplsql/api/DBHelper.java
+++ b/src/main/java/org/utplsql/api/DBHelper.java
@@ -1,7 +1,6 @@
 package org.utplsql.api;
 
 import oracle.jdbc.OracleTypes;
-import org.utplsql.api.exception.DatabaseNotCompatibleException;
 import org.utplsql.api.exception.UtPLSQLNotInstalledException;
 
 import java.sql.*;

--- a/src/main/java/org/utplsql/api/EnvironmentVariableUtil.java
+++ b/src/main/java/org/utplsql/api/EnvironmentVariableUtil.java
@@ -18,6 +18,8 @@ package org.utplsql.api;
  */
 public class EnvironmentVariableUtil {
 
+    private EnvironmentVariableUtil() {}
+
     /**
      * Returns the value for a given key from environment (see class description)
      *
@@ -43,4 +45,6 @@ public class EnvironmentVariableUtil {
 
         return val;
     }
+
+
 }

--- a/src/main/java/org/utplsql/api/FileMapper.java
+++ b/src/main/java/org/utplsql/api/FileMapper.java
@@ -20,7 +20,7 @@ public final class FileMapper {
             Connection conn, FileMapperOptions mapperOptions) throws SQLException {
         OracleConnection oraConn = conn.unwrap(OracleConnection.class);
 
-        Map typeMap = conn.getTypeMap();
+        Map<String, Class<?>> typeMap = conn.getTypeMap();
         typeMap.put(CustomTypes.UT_FILE_MAPPING, FileMapping.class);
         typeMap.put(CustomTypes.UT_KEY_VALUE_PAIR, KeyValuePair.class);
         conn.setTypeMap(typeMap);

--- a/src/main/java/org/utplsql/api/FileMapping.java
+++ b/src/main/java/org/utplsql/api/FileMapping.java
@@ -17,11 +17,18 @@ public class FileMapping implements SQLData {
 
     public FileMapping() {}
 
+    public FileMapping(String fileName, String objectOwner, String objectName, String objectType) {
+        this.fileName = fileName;
+        this.objectOwner = objectOwner;
+        this.objectName = objectName;
+        this.objectType = objectType;
+    }
+
     public String getFileName() {
         return fileName;
     }
 
-    public void setFileName(String fileName) {
+    private void setFileName(String fileName) {
         this.fileName = fileName;
     }
 
@@ -29,7 +36,7 @@ public class FileMapping implements SQLData {
         return objectOwner;
     }
 
-    public void setObjectOwner(String objectOwner) {
+    private void setObjectOwner(String objectOwner) {
         this.objectOwner = objectOwner;
     }
 
@@ -37,7 +44,7 @@ public class FileMapping implements SQLData {
         return objectName;
     }
 
-    public void setObjectName(String objectName) {
+    private void setObjectName(String objectName) {
         this.objectName = objectName;
     }
 
@@ -45,7 +52,7 @@ public class FileMapping implements SQLData {
         return objectType;
     }
 
-    public void setObjectType(String objectType) {
+    private void setObjectType(String objectType) {
         this.objectType = objectType;
     }
 

--- a/src/main/java/org/utplsql/api/JavaApiVersionInfo.java
+++ b/src/main/java/org/utplsql/api/JavaApiVersionInfo.java
@@ -7,6 +7,8 @@ package org.utplsql.api;
  */
 public class JavaApiVersionInfo {
 
+    private JavaApiVersionInfo() { }
+
     private static final String BUILD_NO = "123";
     private static final String MAVEN_PROJECT_NAME = "utPLSQL-java-api";
     private static final String MAVEN_PROJECT_VERSION = "3.1.1-SNAPSHOT";

--- a/src/main/java/org/utplsql/api/KeyValuePair.java
+++ b/src/main/java/org/utplsql/api/KeyValuePair.java
@@ -22,16 +22,8 @@ public class KeyValuePair implements SQLData {
         return key;
     }
 
-    public void setKey(String key) {
-        this.key = key;
-    }
-
     public String getValue() {
         return value;
-    }
-
-    public void setValue(String value) {
-        this.value = value;
     }
 
     @Override
@@ -41,19 +33,19 @@ public class KeyValuePair implements SQLData {
 
     @Override
     public void readSQL(SQLInput stream, String typeName) throws SQLException {
-        setKey(stream.readString());
-        setValue(stream.readString());
+        key = stream.readString();
+        value = stream.readString();
     }
 
     @Override
     public void writeSQL(SQLOutput stream) throws SQLException {
-        stream.writeString(getKey());
-        stream.writeString(getValue());
+        stream.writeString(key);
+        stream.writeString(value);
     }
 
     @Override
     public String toString() {
-        return String.format("%s => %s", getKey(), getValue());
+        return String.format("%s => %s", key, value);
     }
 
 }

--- a/src/main/java/org/utplsql/api/ResourceUtil.java
+++ b/src/main/java/org/utplsql/api/ResourceUtil.java
@@ -21,6 +21,8 @@ import java.util.zip.ZipFile;
  */
 public class ResourceUtil {
 
+    private ResourceUtil() {}
+
     /**
      * Returns the Path to a resource so it is walkable no matter if it's inside a jar or on the file system
      *

--- a/src/main/java/org/utplsql/api/TestRunnerOptions.java
+++ b/src/main/java/org/utplsql/api/TestRunnerOptions.java
@@ -3,7 +3,6 @@ package org.utplsql.api;
 import org.utplsql.api.reporter.Reporter;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,14 +11,14 @@ import java.util.List;
  * @author pesse
  */
 public class TestRunnerOptions {
-    public List<String> pathList = new ArrayList<>();
-    public List<Reporter> reporterList = new ArrayList<>();
+    public final List<String> pathList = new ArrayList<>();
+    public final List<Reporter> reporterList = new ArrayList<>();
     public boolean colorConsole = false;
-    public List<String> coverageSchemes = new ArrayList<>();
-    public List<String> sourceFiles = new ArrayList<>();
-    public List<String> testFiles = new ArrayList<>();
-    public List<String> includeObjects = new ArrayList<>();
-    public List<String> excludeObjects = new ArrayList<>();
+    public final List<String> coverageSchemes = new ArrayList<>();
+    public final List<String> sourceFiles = new ArrayList<>();
+    public final List<String> testFiles = new ArrayList<>();
+    public final List<String> includeObjects = new ArrayList<>();
+    public final List<String> excludeObjects = new ArrayList<>();
     public FileMapperOptions sourceMappingOptions;
     public FileMapperOptions testMappingOptions;
     public boolean failOnErrors = false;

--- a/src/main/java/org/utplsql/api/Version.java
+++ b/src/main/java/org/utplsql/api/Version.java
@@ -85,11 +85,11 @@ public class Version implements Comparable<Version> {
             StringBuilder sb = new StringBuilder();
             sb.append(String.valueOf(major));
             if ( minor != null )
-                sb.append("." + String.valueOf(minor));
+                sb.append(".").append(String.valueOf(minor));
             if ( bugfix != null )
-                sb.append("." + String.valueOf(bugfix));
+                sb.append(".").append(String.valueOf(bugfix));
             if ( build != null )
-                sb.append("." + String.valueOf(build));
+                sb.append(".").append(String.valueOf(build));
 
             return sb.toString();
         }
@@ -152,10 +152,7 @@ public class Version implements Comparable<Version> {
 
         versionsAreValid(v);
 
-        if ( compareTo(v) >= 0 )
-            return true;
-        else
-            return false;
+        return compareTo(v) >= 0;
     }
 
 
@@ -163,10 +160,7 @@ public class Version implements Comparable<Version> {
     {
         versionsAreValid(v);
 
-        if ( compareTo(v) > 0 )
-            return true;
-        else
-            return false;
+        return compareTo(v) > 0;
     }
 
     public boolean isLessOrEqualThan( Version v ) throws InvalidVersionException
@@ -174,19 +168,13 @@ public class Version implements Comparable<Version> {
 
         versionsAreValid(v);
 
-        if ( compareTo(v) <= 0 )
-            return true;
-        else
-            return false;
+        return compareTo(v) <= 0;
     }
 
     public boolean isLessThan( Version v) throws InvalidVersionException
     {
         versionsAreValid(v);
 
-        if ( compareTo(v) < 0 )
-            return true;
-        else
-            return false;
+        return compareTo(v) < 0;
     }
 }

--- a/src/main/java/org/utplsql/api/Version.java
+++ b/src/main/java/org/utplsql/api/Version.java
@@ -10,44 +10,52 @@ import java.util.regex.Pattern;
  * @author pesse
  */
 public class Version implements Comparable<Version> {
-    private String origString;
-    private Integer major;
-    private Integer minor;
-    private Integer bugfix;
-    private Integer build;
-    private boolean valid = false;
+    private final String origString;
+    private final Integer major;
+    private final Integer minor;
+    private final Integer bugfix;
+    private final Integer build;
+    private final boolean valid;
 
     public Version( String versionString ) {
         assert versionString != null;
-        this.origString = versionString;
-        parseVersionString();
-    }
+        this.origString = versionString.trim();
 
-    private void parseVersionString()
-    {
         Pattern p = Pattern.compile("([0-9]+)\\.?([0-9]+)?\\.?([0-9]+)?\\.?([0-9]+)?");
 
         Matcher m = p.matcher(origString);
 
+        Integer major = null;
+        Integer minor = null;
+        Integer bugfix = null;
+        Integer build = null;
+        boolean valid = false;
+
         try {
             if (m.find()) {
-                if ( m.group(1) != null )
+                if (m.group(1) != null )
                     major = Integer.valueOf(m.group(1));
-                if ( m.group(2) != null )
+                if (m.group(2) != null )
                     minor = Integer.valueOf(m.group(2));
-                if ( m.group(3) != null )
+                if (m.group(3) != null )
                     bugfix = Integer.valueOf(m.group(3));
-                if ( m.group(4) != null )
+                if (m.group(4) != null )
                     build = Integer.valueOf(m.group(4));
 
-                if ( major != null ) // We need a valid major version as minimum requirement for a Version object to be valid
-                    valid = true;
+                 // We need a valid major version as minimum requirement for a Version object to be valid
+                valid = major != null;
             }
         }
         catch ( NumberFormatException e )
         {
             valid = false;
         }
+
+        this.major = major;
+        this.minor = minor;
+        this.bugfix = bugfix;
+        this.build = build;
+        this.valid = valid;
     }
 
     @Override

--- a/src/main/java/org/utplsql/api/compatibility/CompatibilityProxy.java
+++ b/src/main/java/org/utplsql/api/compatibility/CompatibilityProxy.java
@@ -79,9 +79,7 @@ public class CompatibilityProxy {
      */
     private boolean versionCompatibilityCheck(Connection conn, String requested, String current)
             throws SQLException {
-        CallableStatement callableStatement = null;
-        try {
-            callableStatement = conn.prepareCall("BEGIN ? := ut_runner.version_compatibility_check(?, ?); END;");
+        try(CallableStatement callableStatement = conn.prepareCall("BEGIN ? := ut_runner.version_compatibility_check(?, ?); END;")) {
             callableStatement.registerOutParameter(1, Types.SMALLINT);
             callableStatement.setString(2, requested);
 
@@ -97,9 +95,6 @@ public class CompatibilityProxy {
                 return false;
             else
                 throw e;
-        } finally {
-            if (callableStatement != null)
-                callableStatement.close();
         }
     }
 
@@ -108,11 +103,11 @@ public class CompatibilityProxy {
      * @param requested
      * @return
      */
-    private boolean versionCompatibilityCheckPre303( String requested )
+    private boolean versionCompatibilityCheckPre303(String requested )
     {
         Version requesteVersion = new Version(requested);
 
-        if ( databaseVersion.getMajor() == requesteVersion.getMajor() && (requesteVersion.getMinor() == null || databaseVersion.getMinor() == requesteVersion.getMinor()) )
+        if (databaseVersion.getMajor().equals(requesteVersion.getMajor()) && (requesteVersion.getMinor() == null || requesteVersion.getMinor().equals(databaseVersion.getMinor())) )
             return true;
         else
             return false;

--- a/src/main/java/org/utplsql/api/compatibility/OptionalFeatures.java
+++ b/src/main/java/org/utplsql/api/compatibility/OptionalFeatures.java
@@ -26,12 +26,8 @@ public enum OptionalFeatures {
     public boolean isAvailableFor(Version version ) {
 
         try {
-            if ((minVersion == null || version.isGreaterOrEqualThan(minVersion)) &&
-                    (maxVersion == null || maxVersion.isGreaterOrEqualThan(version))
-                    )
-                return true;
-            else
-                return false;
+            return (minVersion == null || version.isGreaterOrEqualThan(minVersion)) &&
+                    (maxVersion == null || maxVersion.isGreaterOrEqualThan(version));
         } catch ( InvalidVersionException e ) {
             return false; // We have no optional features for invalid versions
         }

--- a/src/main/java/org/utplsql/api/compatibility/OptionalFeatures.java
+++ b/src/main/java/org/utplsql/api/compatibility/OptionalFeatures.java
@@ -12,15 +12,13 @@ public enum OptionalFeatures {
     FRAMEWORK_COMPATIBILITY_CHECK("3.0.3", null),
     CUSTOM_REPORTERS("3.1.0", null);
 
-    private Version minVersion;
-    private Version maxVersion;
+    private final Version minVersion;
+    private final Version maxVersion;
 
     OptionalFeatures( String minVersion, String maxVersion )
     {
-        if ( minVersion != null )
-            this.minVersion = new Version(minVersion);
-        if ( maxVersion != null)
-            this.maxVersion = new Version(maxVersion);
+        this.minVersion = minVersion != null ? new Version(minVersion) : null;
+        this.maxVersion = maxVersion != null ? new Version(maxVersion) : null;
     }
 
     public boolean isAvailableFor(Version version ) {

--- a/src/main/java/org/utplsql/api/exception/DatabaseNotCompatibleException.java
+++ b/src/main/java/org/utplsql/api/exception/DatabaseNotCompatibleException.java
@@ -1,6 +1,5 @@
 package org.utplsql.api.exception;
 
-import org.utplsql.api.DBHelper;
 import org.utplsql.api.Version;
 import org.utplsql.api.compatibility.CompatibilityProxy;
 
@@ -13,8 +12,8 @@ import java.sql.SQLException;
  */
 public class DatabaseNotCompatibleException extends SQLException {
 
-    private Version clientVersion;
-    private Version databaseVersion;
+    private final Version clientVersion;
+    private final Version databaseVersion;
 
     public DatabaseNotCompatibleException( String message, Version clientVersion, Version databaseVersion, Throwable cause )
     {

--- a/src/main/java/org/utplsql/api/exception/InvalidVersionException.java
+++ b/src/main/java/org/utplsql/api/exception/InvalidVersionException.java
@@ -7,7 +7,7 @@ import org.utplsql.api.Version;
  * @author pesse
  */
 public class InvalidVersionException extends Exception {
-    private Version version;
+    private final Version version;
 
     public InvalidVersionException( Version version ) {
         this( version, null );

--- a/src/main/java/org/utplsql/api/outputBuffer/AbstractOutputBuffer.java
+++ b/src/main/java/org/utplsql/api/outputBuffer/AbstractOutputBuffer.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
  */
 abstract class AbstractOutputBuffer implements OutputBuffer {
 
-    private Reporter reporter;
+    private final Reporter reporter;
     private int fetchSize = 100;
 
     /**

--- a/src/main/java/org/utplsql/api/outputBuffer/NonOutputBuffer.java
+++ b/src/main/java/org/utplsql/api/outputBuffer/NonOutputBuffer.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
  */
 class NonOutputBuffer implements OutputBuffer {
 
-    private Reporter reporter;
+    private final Reporter reporter;
 
     NonOutputBuffer( Reporter reporter) {
         this.reporter = reporter;

--- a/src/main/java/org/utplsql/api/outputBuffer/OutputBufferProvider.java
+++ b/src/main/java/org/utplsql/api/outputBuffer/OutputBufferProvider.java
@@ -60,4 +60,7 @@ public class OutputBufferProvider {
             }
         }
     }
+
+    private OutputBufferProvider() {
+    }
 }

--- a/src/main/java/org/utplsql/api/outputBuffer/OutputBufferProvider.java
+++ b/src/main/java/org/utplsql/api/outputBuffer/OutputBufferProvider.java
@@ -34,7 +34,7 @@ public class OutputBufferProvider {
                }
            }
        }
-       catch ( InvalidVersionException e ) { }
+       catch ( InvalidVersionException ignored ) { }
 
        // If we couldn't find an appropriate OutputBuffer, return the Pre310-Compatibility-Buffer
        return new CompatibilityOutputBufferPre310(reporter);
@@ -52,10 +52,8 @@ public class OutputBufferProvider {
 
                     if ( isReporterResult == null )
                         throw new IllegalArgumentException("The given type " + reporter.getTypeName() + " is not a valid Reporter!");
-                    else if (isReporterResult.equalsIgnoreCase("Y") )
-                        return true;
                     else
-                        return false;
+                        return isReporterResult.equalsIgnoreCase("Y");
                 }
                 else
                     throw new SQLException("Could not check Reporter validity");

--- a/src/main/java/org/utplsql/api/reporter/CoreReporters.java
+++ b/src/main/java/org/utplsql/api/reporter/CoreReporters.java
@@ -19,8 +19,8 @@ public enum CoreReporters {
     UT_SONAR_TEST_REPORTER(new Version("3.0.0"), null),
     UT_COVERAGE_COBERTURA_REPORTER(new Version("3.1.0"), null);
 
-    private Version since;
-    private Version until;
+    private final Version since;
+    private final Version until;
 
     CoreReporters(Version since, Version until ) {
         this.since = since;
@@ -46,7 +46,7 @@ public enum CoreReporters {
                     && (until == null || databaseVersion.isLessOrEqualThan(until)))
                 return true;
         }
-        catch ( InvalidVersionException e ) { }
+        catch ( InvalidVersionException ignored ) { }
 
         return false;
     }

--- a/src/main/java/org/utplsql/api/reporter/ReporterFactory.java
+++ b/src/main/java/org/utplsql/api/reporter/ReporterFactory.java
@@ -30,11 +30,11 @@ public final class ReporterFactory implements ORADataFactory {
             this.factoryMethod = factoryMethod;
             this.description = description;
         }
-        public BiFunction<String, Object[], ? extends Reporter> factoryMethod;
-        public String description;
+        public final BiFunction<String, Object[], ? extends Reporter> factoryMethod;
+        public final String description;
     }
 
-    private Map<String, ReporterFactoryMethodInfo> reportFactoryMethodMap = new HashMap<>();
+    private final Map<String, ReporterFactoryMethodInfo> reportFactoryMethodMap = new HashMap<>();
 
     ReporterFactory() { }
 

--- a/src/main/java/org/utplsql/api/reporter/inspect/AbstractReporterInspector.java
+++ b/src/main/java/org/utplsql/api/reporter/inspect/AbstractReporterInspector.java
@@ -3,33 +3,15 @@ package org.utplsql.api.reporter.inspect;
 import org.utplsql.api.reporter.ReporterFactory;
 
 import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 abstract class AbstractReporterInspector implements ReporterInspector  {
 
     protected final ReporterFactory reporterFactory;
     protected final Connection connection;
-    protected final Set<ReporterInfo> infos;
 
-    AbstractReporterInspector(ReporterFactory reporterFactory, Connection conn ) throws SQLException {
+    AbstractReporterInspector(ReporterFactory reporterFactory, Connection conn ) {
         this.reporterFactory = reporterFactory;
         this.connection = conn;
-        this.infos = loadReporterInfos();
-    }
-
-    protected abstract Set<ReporterInfo> loadReporterInfos() throws SQLException;
-
-    @Override
-    public Map<String, ReporterInfo> getReporterInfoMap() {
-        return infos.stream().collect(Collectors.toMap(ReporterInfo::getName, Function.identity()));
-    }
-
-    @Override
-    public List<ReporterInfo> getReporterInfos() {
-        return new ArrayList<>(infos);
     }
 
 }

--- a/src/main/java/org/utplsql/api/reporter/inspect/AbstractReporterInspector.java
+++ b/src/main/java/org/utplsql/api/reporter/inspect/AbstractReporterInspector.java
@@ -4,30 +4,27 @@ import org.utplsql.api.reporter.ReporterFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 abstract class AbstractReporterInspector implements ReporterInspector  {
 
-    protected ReporterFactory reporterFactory;
-    protected Connection connection;
-    protected Set<ReporterInfo> infos;
+    protected final ReporterFactory reporterFactory;
+    protected final Connection connection;
+    protected final Set<ReporterInfo> infos;
 
     AbstractReporterInspector(ReporterFactory reporterFactory, Connection conn ) throws SQLException {
         this.reporterFactory = reporterFactory;
         this.connection = conn;
-
-        load();
+        this.infos = loadReporterInfos();
     }
 
-    protected abstract void load() throws SQLException;
+    protected abstract Set<ReporterInfo> loadReporterInfos() throws SQLException;
 
     @Override
     public Map<String, ReporterInfo> getReporterInfoMap() {
-        return infos.stream().collect(Collectors.toMap(ReporterInfo::getName, i -> i));
+        return infos.stream().collect(Collectors.toMap(ReporterInfo::getName, Function.identity()));
     }
 
     @Override

--- a/src/main/java/org/utplsql/api/reporter/inspect/ReporterInfo.java
+++ b/src/main/java/org/utplsql/api/reporter/inspect/ReporterInfo.java
@@ -10,9 +10,9 @@ public class ReporterInfo {
         SQL, JAVA, SQL_WITH_JAVA
     }
 
-    private String name;
-    private Type type;
-    private String description;
+    private final String name;
+    private final Type type;
+    private final String description;
 
     ReporterInfo( String name, Type type, String description ) {
         this.name = name;

--- a/src/main/java/org/utplsql/api/reporter/inspect/ReporterInspector.java
+++ b/src/main/java/org/utplsql/api/reporter/inspect/ReporterInspector.java
@@ -9,6 +9,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Gives information about available reporters
@@ -19,7 +21,9 @@ public interface ReporterInspector {
 
     List<ReporterInfo> getReporterInfos();
 
-    Map<String, ReporterInfo> getReporterInfoMap();
+    default Map<String, ReporterInfo> getReporterInfoMap() {
+        return getReporterInfos().stream().collect(Collectors.toMap(ReporterInfo::getName, Function.identity()));
+    }
 
     /**
      * Returns a new instance of a ReporterInspector, based on the utPLSQL version used in the connection

--- a/src/main/java/org/utplsql/api/reporter/inspect/ReporterInspector310.java
+++ b/src/main/java/org/utplsql/api/reporter/inspect/ReporterInspector310.java
@@ -20,16 +20,12 @@ import java.util.*;
 class ReporterInspector310 extends AbstractReporterInspector {
 
     private final Map<String, String> registeredReporterFactoryMethods;
+    private final Set<ReporterInfo> infos;
 
     ReporterInspector310(ReporterFactory reporterFactory, Connection conn ) throws SQLException {
         super(reporterFactory, conn);
-
         registeredReporterFactoryMethods = reporterFactory.getRegisteredReporterInfo();
 
-    }
-
-    @Override
-    protected Set<ReporterInfo> loadReporterInfos() throws SQLException {
         Set<ReporterInfo> reporterInfos = new HashSet<>();
         try (PreparedStatement stmt = connection.prepareStatement("select * from table(ut_runner.get_reporters_list) order by 1")) {
             try (ResultSet rs = stmt.executeQuery() ) {
@@ -37,10 +33,16 @@ class ReporterInspector310 extends AbstractReporterInspector {
                     reporterInfos.add(getReporterInfo(rs.getString(1)));
             }
         }
-        return reporterInfos;
+        this.infos = reporterInfos;
+
     }
 
-    private ReporterInfo getReporterInfo( String reporterNameWithOwner ) throws SQLException {
+    @Override
+    public List<ReporterInfo> getReporterInfos() {
+        return new ArrayList<>(infos);
+    }
+
+    private ReporterInfo getReporterInfo(String reporterNameWithOwner ) throws SQLException {
         String reporterName = reporterNameWithOwner.substring(reporterNameWithOwner.indexOf(".")+1).toUpperCase();
 
         ReporterInfo.Type type = ReporterInfo.Type.SQL;

--- a/src/main/java/org/utplsql/api/testRunner/AbstractTestRunnerStatement.java
+++ b/src/main/java/org/utplsql/api/testRunner/AbstractTestRunnerStatement.java
@@ -1,8 +1,10 @@
 package org.utplsql.api.testRunner;
 
 import oracle.jdbc.OracleConnection;
-import org.utplsql.api.*;
-import org.utplsql.api.exception.SomeTestsFailedException;
+import org.utplsql.api.CustomTypes;
+import org.utplsql.api.FileMapper;
+import org.utplsql.api.FileMapping;
+import org.utplsql.api.TestRunnerOptions;
 
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -10,20 +12,23 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
 
-/** Abstract class which creates a callable statement for running tests
+/**
+ * Abstract class which creates a callable statement for running tests
  * The SQL to be used has to be implemented for there are differences between the Framework-versions
  *
  * @author pesse
  */
 abstract class AbstractTestRunnerStatement implements TestRunnerStatement {
 
-    protected TestRunnerOptions options;
-    protected Connection conn;
-    protected CallableStatement callableStatement;
+    protected final TestRunnerOptions options;
+    protected final Connection conn;
+    protected final CallableStatement callableStatement;
 
     public AbstractTestRunnerStatement(TestRunnerOptions options, Connection conn) throws SQLException {
         this.options = options;
         this.conn = conn;
+
+        callableStatement = conn.prepareCall(getSql());
 
         createStatement();
     }
@@ -33,8 +38,6 @@ abstract class AbstractTestRunnerStatement implements TestRunnerStatement {
     protected int createStatement() throws SQLException {
 
         OracleConnection oraConn = conn.unwrap(OracleConnection.class);
-
-        callableStatement = conn.prepareCall(getSql());
 
         int paramIdx = 0;
 
@@ -90,6 +93,7 @@ abstract class AbstractTestRunnerStatement implements TestRunnerStatement {
         callableStatement.execute();
     }
 
+    @Override
     public void close() throws SQLException {
         if (callableStatement != null)
             callableStatement.close();

--- a/src/main/java/org/utplsql/api/testRunner/TestRunnerStatement.java
+++ b/src/main/java/org/utplsql/api/testRunner/TestRunnerStatement.java
@@ -2,13 +2,15 @@ package org.utplsql.api.testRunner;
 
 import java.sql.SQLException;
 
-/** Interface to hide the concrete Statement-implementations of TestRunner
+/**
+ * Interface to hide the concrete Statement-implementations of TestRunner
  *
  * @author pesse
  */
-public interface TestRunnerStatement {
+public interface TestRunnerStatement extends AutoCloseable {
 
     void execute() throws SQLException;
 
+    @Override
     void close() throws SQLException;
 }

--- a/src/main/java/org/utplsql/api/testRunner/TestRunnerStatementProvider.java
+++ b/src/main/java/org/utplsql/api/testRunner/TestRunnerStatementProvider.java
@@ -1,9 +1,7 @@
 package org.utplsql.api.testRunner;
 
-import org.utplsql.api.DBHelper;
 import org.utplsql.api.TestRunnerOptions;
 import org.utplsql.api.Version;
-import org.utplsql.api.compatibility.OptionalFeatures;
 import org.utplsql.api.exception.InvalidVersionException;
 
 import java.sql.Connection;
@@ -32,7 +30,7 @@ public class TestRunnerStatementProvider {
             else if (databaseVersion.isLessThan(new Version("3.1.2")))
                 stmt = new Pre312TestRunnerStatement(options, conn);
 
-        } catch ( InvalidVersionException e ) {}
+        } catch ( InvalidVersionException ignored ) {}
 
         if ( stmt == null )
             stmt = new ActualTestRunnerStatement(options, conn);

--- a/src/main/java/org/utplsql/api/testRunner/TestRunnerStatementProvider.java
+++ b/src/main/java/org/utplsql/api/testRunner/TestRunnerStatementProvider.java
@@ -37,4 +37,7 @@ public class TestRunnerStatementProvider {
 
         return stmt;
     }
+
+    private TestRunnerStatementProvider() {
+    }
 }

--- a/src/test/java/org/utplsql/api/RegisterCustomReporterTest.java
+++ b/src/test/java/org/utplsql/api/RegisterCustomReporterTest.java
@@ -1,7 +1,6 @@
 package org.utplsql.api;
 
 import org.junit.jupiter.api.Test;
-import org.utplsql.api.compatibility.CompatibilityProxy;
 import org.utplsql.api.reporter.DefaultReporter;
 import org.utplsql.api.reporter.Reporter;
 import org.utplsql.api.reporter.ReporterFactory;

--- a/src/test/java/org/utplsql/api/ReporterInspectorIT.java
+++ b/src/test/java/org/utplsql/api/ReporterInspectorIT.java
@@ -1,25 +1,18 @@
 package org.utplsql.api;
 
-import oracle.jdbc.OracleCallableStatement;
-import oracle.jdbc.OracleConnection;
-import oracle.jdbc.OracleType;
 import org.junit.jupiter.api.Test;
 import org.utplsql.api.compatibility.CompatibilityProxy;
 import org.utplsql.api.exception.InvalidVersionException;
 import org.utplsql.api.reporter.CoreReporters;
-import org.utplsql.api.reporter.Reporter;
 import org.utplsql.api.reporter.ReporterFactory;
 import org.utplsql.api.reporter.inspect.ReporterInfo;
 import org.utplsql.api.reporter.inspect.ReporterInspector;
 
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.SQLType;
 import java.util.Comparator;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ReporterInspectorIT extends AbstractDatabaseTest {
 

--- a/src/test/java/org/utplsql/api/TestRunnerIT.java
+++ b/src/test/java/org/utplsql/api/TestRunnerIT.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.utplsql.api.compatibility.CompatibilityProxy;
 import org.utplsql.api.exception.InvalidVersionException;
 import org.utplsql.api.exception.SomeTestsFailedException;
-import org.utplsql.api.reporter.*;
+import org.utplsql.api.reporter.CoreReporters;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/test/java/org/utplsql/api/VersionObjectTest.java
+++ b/src/test/java/org/utplsql/api/VersionObjectTest.java
@@ -3,9 +3,7 @@ package org.utplsql.api;
 import org.junit.jupiter.api.Test;
 import org.utplsql.api.exception.InvalidVersionException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class VersionObjectTest {
 

--- a/src/test/java/org/utplsql/api/reporter/CoverageHTMLReporterAssetTest.java
+++ b/src/test/java/org/utplsql/api/reporter/CoverageHTMLReporterAssetTest.java
@@ -3,12 +3,12 @@ package org.utplsql.api.reporter;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CoverageHTMLReporterAssetTest {
 

--- a/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
+++ b/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
@@ -8,7 +8,6 @@ import org.utplsql.api.Version;
 import java.sql.SQLException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
 


### PR DESCRIPTION
Trivial cleanup (remove unnecessary imports, making properties final, simplified if statements etc) based on IDEA code inspector

Refactored creation of ReporterInspectors. Made them immutable, separated creation from ReporterInfo collection fill
Made TestRunnerStatement AutoClosable to be used with try-with-resource
For SQLData implementations (FileMapping, KeyValuePair) made setters private