### PR TITLE
Improve Reporter hasOutput-Check

### DIFF
--- a/src/main/java/org/utplsql/api/outputBuffer/OutputBufferProvider.java
+++ b/src/main/java/org/utplsql/api/outputBuffer/OutputBufferProvider.java
@@ -42,9 +42,13 @@ public class OutputBufferProvider {
 
     private static boolean hasOutput( Reporter reporter, OracleConnection oraConn ) throws SQLException {
 
-        String sql = "select is_output_reporter from table(ut_runner.get_reporters_list) where regexp_like(reporter_object_name, ?)";
+        String sql = "select is_output_reporter " +
+                " from table(ut_runner.get_reporters_list)" +
+                " where ? = substr(reporter_object_name, length(reporter_object_name)-?+1)";
         try ( PreparedStatement stmt = oraConn.prepareStatement(sql)) {
-            stmt.setString(1, "[a-zA-Z0-9_]*\\.?" + reporter.getTypeName());
+            stmt.setQueryTimeout(3);
+            stmt.setString(1, reporter.getTypeName());
+            stmt.setInt(2, reporter.getTypeName().length());
 
             try ( ResultSet rs = stmt.executeQuery() ) {
                 if ( rs.next() ) {


### PR DESCRIPTION
There might be a problem of pipelined functions limited by regexp_like
in 11g we can probably avoid with a different approach.
Additionally, setting a Statement-Timeout here will prevent the cli to
wait forever in case of an error.