### PR TITLE
Fix jar file name on packagecloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,15 @@ deploy:
       # Use only first job "#xxx.1" to publish artifacts
       condition: "${TRAVIS_JOB_NUMBER} =~ \\.1$"
 
+  - provider: script
+    script: ./gradlew uploadArchives
+    skip_cleanup: true
+    on:
+      repository: utPLSQL/utPLSQL-java-api
+      branch: fix-artifactid
+      # Use only first job "#xxx.1" to publish artifacts
+      condition: "${TRAVIS_JOB_NUMBER} =~ \\.1$"
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,15 +77,6 @@ deploy:
       # Use only first job "#xxx.1" to publish artifacts
       condition: "${TRAVIS_JOB_NUMBER} =~ \\.1$"
 
-  - provider: script
-    script: ./gradlew uploadArchives
-    skip_cleanup: true
-    on:
-      repository: utPLSQL/utPLSQL-java-api
-      branch: fix-artifactid
-      # Use only first job "#xxx.1" to publish artifacts
-      condition: "${TRAVIS_JOB_NUMBER} =~ \\.1$"
-
 notifications:
   slack:
     rooms:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,6 @@ tasks {
 
     val coverageResourcesDirectory = "${project.buildDir}/resources/main/CoverageHTMLReporter"
     val coverageResourcesZip = "${project.buildDir}/utPLSQL-coverage-html-$coverageResourcesVersion.zip"
-
     // download Coverage Resources from web
     val downloadResources = create<Download>("downloadCoverageResources") {
         src("https://codeload.github.com/utPLSQL/utPLSQL-coverage-html/zip/$coverageResourcesVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,7 +131,7 @@ tasks {
             from("$buildDir/publications/maven")
             rename(".*", "pom.xml")
         }
-
+        archiveBaseName.set("java-api")
     }
 
     named<Upload>("uploadArchives") {


### PR DESCRIPTION
When migrated to Gradle I've broken the jar file name. It changed to utPLSQL-java-api-3.1.3-SNAPSHOT.jar from  java-api-3.1.3-SNAPSHOT.jar.

The PR is fixing that.
