### PR TITLE
Feature/add support for random order of execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - UTPLSQL_VERSION="v3.1.1"
     - UTPLSQL_VERSION="v3.1.2"
     - UTPLSQL_VERSION="v3.1.3"
+    - UTPLSQL_VERSION="v3.1.6"
     - UTPLSQL_VERSION="develop"
       UTPLSQL_FILE="utPLSQL"
 

--- a/src/main/java/org/utplsql/api/TestRunner.java
+++ b/src/main/java/org/utplsql/api/TestRunner.java
@@ -129,6 +129,8 @@ public class TestRunner {
         return this;
     }
 
+    public TestRunnerOptions getOptions() { return options; }
+
     private void delayedAddReporters() {
         if (reporterFactory != null) {
             reporterNames.forEach(this::addReporter);

--- a/src/main/java/org/utplsql/api/TestRunner.java
+++ b/src/main/java/org/utplsql/api/TestRunner.java
@@ -118,6 +118,17 @@ public class TestRunner {
         return this;
     }
 
+    public TestRunner randomTestOrder(boolean randomTestOrder ) {
+        this.options.randomTestOrder = randomTestOrder;
+        return this;
+    }
+
+    public TestRunner randomTestOrderSeed( Integer seed ) {
+        this.options.randomTestOrderSeed = seed;
+        if ( seed != null ) this.options.randomTestOrder = true;
+        return this;
+    }
+
     private void delayedAddReporters() {
         if (reporterFactory != null) {
             reporterNames.forEach(this::addReporter);

--- a/src/main/java/org/utplsql/api/TestRunnerOptions.java
+++ b/src/main/java/org/utplsql/api/TestRunnerOptions.java
@@ -25,4 +25,6 @@ public class TestRunnerOptions {
     public boolean failOnErrors = false;
     public boolean skipCompatibilityCheck = false;
     public String clientCharacterSet = Charset.defaultCharset().toString();
+    public boolean randomTestOrder = false;
+    public Integer randomTestOrderSeed;
 }

--- a/src/main/java/org/utplsql/api/Version.java
+++ b/src/main/java/org/utplsql/api/Version.java
@@ -31,10 +31,11 @@ public class Version implements Comparable<Version> {
     public final static Version V3_1_4 = new Version("3.1.4", 3, 1, 4, null, true);
     public final static Version V3_1_5 = new Version("3.1.5", 3, 1, 5, null, true);
     public final static Version V3_1_6 = new Version("3.1.6", 3, 1, 6, null, true);
+    public final static Version V3_1_7 = new Version("3.1.7", 3, 1, 7, null, true);
     private final static Map<String, Version> knownVersions =
-            Stream.of(V3_0_0, V3_0_1, V3_0_2, V3_0_3, V3_0_4, V3_1_0, V3_1_1, V3_1_2, V3_1_3, V3_1_4, V3_1_5, V3_1_6)
+            Stream.of(V3_0_0, V3_0_1, V3_0_2, V3_0_3, V3_0_4, V3_1_0, V3_1_1, V3_1_2, V3_1_3, V3_1_4, V3_1_5, V3_1_6, V3_1_7)
                     .collect(toMap(Version::toString, Function.identity()));
-    public final static Version LATEST = V3_1_6;
+    public final static Version LATEST = V3_1_7;
 
     private final String origString;
     private final Integer major;

--- a/src/main/java/org/utplsql/api/compatibility/OptionalFeatures.java
+++ b/src/main/java/org/utplsql/api/compatibility/OptionalFeatures.java
@@ -11,7 +11,8 @@ public enum OptionalFeatures {
     FAIL_ON_ERROR("3.0.3.1266", null),
     FRAMEWORK_COMPATIBILITY_CHECK("3.0.3.1266", null),
     CUSTOM_REPORTERS("3.1.0.1849", null),
-    CLIENT_CHARACTER_SET("3.1.2.2130", null);
+    CLIENT_CHARACTER_SET("3.1.2.2130", null),
+    RANDOM_EXECUTION_ORDER("3.1.7.2795", null);
 
     private final Version minVersion;
     private final Version maxVersion;

--- a/src/main/java/org/utplsql/api/testRunner/ActualTestRunnerStatement.java
+++ b/src/main/java/org/utplsql/api/testRunner/ActualTestRunnerStatement.java
@@ -4,6 +4,7 @@ import org.utplsql.api.TestRunnerOptions;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Types;
 
 /**
  * Provides the call to run tests for the most actual Framework version.
@@ -27,17 +28,18 @@ class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
         return
                 "BEGIN " +
                         "ut_runner.run(" +
-                        "a_paths                => ?, " +
-                        "a_reporters            => ?, " +
-                        "a_color_console        => " + colorConsoleStr + ", " +
-                        "a_coverage_schemes     => ?, " +
-                        "a_source_file_mappings => ?, " +
-                        "a_test_file_mappings   => ?, " +
-                        "a_include_objects      => ?, " +
-                        "a_exclude_objects      => ?, " +
-                        "a_fail_on_errors       => " + failOnErrors + ", " +
-                        "a_client_character_set => ?" +
-                        //(options.randomTestOrderSeed != null ) ?
+                        "a_paths                  => ?, " +
+                        "a_reporters              => ?, " +
+                        "a_color_console          => " + colorConsoleStr + ", " +
+                        "a_coverage_schemes       => ?, " +
+                        "a_source_file_mappings   => ?, " +
+                        "a_test_file_mappings     => ?, " +
+                        "a_include_objects        => ?, " +
+                        "a_exclude_objects        => ?, " +
+                        "a_fail_on_errors         => " + failOnErrors + ", " +
+                        "a_client_character_set   => ?, " +
+                        "a_random_test_order      => " + randomExecutionOrder + ", " +
+                        "a_random_test_order_seed => ?"+
                         "); " +
                         "END;";
     }
@@ -47,6 +49,11 @@ class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
         int curParamIdx = super.createStatement();
 
         callableStatement.setString(++curParamIdx, options.clientCharacterSet);
+        if ( options.randomTestOrderSeed == null ) {
+            callableStatement.setNull(++curParamIdx, Types.INTEGER);
+        } else {
+            callableStatement.setInt(++curParamIdx, options.randomTestOrderSeed);
+        }
 
         return curParamIdx;
     }

--- a/src/main/java/org/utplsql/api/testRunner/Pre317TestRunnerStatement.java
+++ b/src/main/java/org/utplsql/api/testRunner/Pre317TestRunnerStatement.java
@@ -11,9 +11,9 @@ import java.sql.SQLException;
  *
  * @author pesse
  */
-class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
+class Pre317TestRunnerStatement extends AbstractTestRunnerStatement {
 
-    public ActualTestRunnerStatement(TestRunnerOptions options, Connection connection) throws SQLException {
+    public Pre317TestRunnerStatement(TestRunnerOptions options, Connection connection) throws SQLException {
         super(options, connection);
     }
 
@@ -22,7 +22,6 @@ class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
         // Workaround because Oracle JDBC doesn't support passing boolean to stored procedures.
         String colorConsoleStr = Boolean.toString(options.colorConsole);
         String failOnErrors = Boolean.toString(options.failOnErrors);
-        String randomExecutionOrder = Boolean.toString(options.randomTestOrder);
 
         return
                 "BEGIN " +
@@ -36,9 +35,7 @@ class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
                         "a_include_objects      => ?, " +
                         "a_exclude_objects      => ?, " +
                         "a_fail_on_errors       => " + failOnErrors + ", " +
-                        "a_client_character_set => ?" +
-                        //(options.randomTestOrderSeed != null ) ?
-                        "); " +
+                        "a_client_character_set => ?); " +
                         "END;";
     }
 

--- a/src/main/java/org/utplsql/api/testRunner/TestRunnerStatementProvider.java
+++ b/src/main/java/org/utplsql/api/testRunner/TestRunnerStatementProvider.java
@@ -35,6 +35,8 @@ public class TestRunnerStatementProvider {
                 stmt = new Pre303TestRunnerStatement(options, conn);
             } else if (databaseVersion.isLessThan(Version.V3_1_2)) {
                 stmt = new Pre312TestRunnerStatement(options, conn);
+            } else if (databaseVersion.isLessThan(Version.V3_1_7)) {
+                stmt = new Pre317TestRunnerStatement(options, conn);
             }
 
         } catch (InvalidVersionException ignored) {

--- a/src/test/java/org/utplsql/api/OptionalFeaturesIT.java
+++ b/src/test/java/org/utplsql/api/OptionalFeaturesIT.java
@@ -64,4 +64,15 @@ class OptionalFeaturesIT extends AbstractDatabaseTest {
             assertFalse(available);
         }
     }
+
+    @Test
+    void randomExecutionOrder() throws SQLException, InvalidVersionException {
+        boolean available = OptionalFeatures.RANDOM_EXECUTION_ORDER.isAvailableFor(getConnection());
+
+        if (getDatabaseVersion().isGreaterOrEqualThan(Version.V3_1_7)) {
+            assertTrue(available);
+        } else {
+            assertFalse(available);
+        }
+    }
 }

--- a/src/test/java/org/utplsql/api/TestRunnerIT.java
+++ b/src/test/java/org/utplsql/api/TestRunnerIT.java
@@ -38,7 +38,7 @@ class TestRunnerIT extends AbstractDatabaseTest {
         DatabaseInformation databaseInformation = new DefaultDatabaseInformation();
 
         // We can only test this for the versions of the latest TestRunnerStatement-Change
-        if ( OptionalFeatures.CLIENT_CHARACTER_SET.isAvailableFor(databaseInformation.getUtPlsqlFrameworkVersion(getConnection())) ) {
+        if ( OptionalFeatures.RANDOM_EXECUTION_ORDER.isAvailableFor(databaseInformation.getUtPlsqlFrameworkVersion(getConnection())) ) {
             new TestRunner()
                     .skipCompatibilityCheck(true)
                     .run(getConnection());

--- a/src/test/java/org/utplsql/api/TestRunnerIT.java
+++ b/src/test/java/org/utplsql/api/TestRunnerIT.java
@@ -78,4 +78,14 @@ class TestRunnerIT extends AbstractDatabaseTest {
         }
     }
 
+    @Test
+    void runWithRandomExecutionOrder() throws SQLException {
+        CompatibilityProxy proxy = new CompatibilityProxy(getConnection());
+
+        new TestRunner()
+                .randomTestOrder(true)
+                .randomTestOrderSeed(123)
+                .run(getConnection());
+    }
+
 }

--- a/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
+++ b/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
@@ -31,8 +31,20 @@ class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
     }
 
     @Test
-    void testGettingActualVersion() throws SQLException {
+    void testGettingPre317Version_from_312() throws SQLException {
         TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.V3_1_2, new TestRunnerOptions(), getConnection());
+        assertEquals(Pre317TestRunnerStatement.class, stmt.getClass());
+    }
+
+    @Test
+    void testGettingPre317Version_from_316() throws SQLException {
+        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.V3_1_6, new TestRunnerOptions(), getConnection());
+        assertEquals(Pre317TestRunnerStatement.class, stmt.getClass());
+    }
+
+    @Test
+    void testGettingActualVersion_from_latest() throws SQLException {
+        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.LATEST, new TestRunnerOptions(), getConnection());
         assertEquals(ActualTestRunnerStatement.class, stmt.getClass());
     }
 }

--- a/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
+++ b/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
@@ -7,44 +7,76 @@ import org.utplsql.api.Version;
 
 import java.sql.SQLException;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
 
+    AbstractTestRunnerStatement getTestRunnerStatementForVersion( Version version ) throws SQLException {
+        return (AbstractTestRunnerStatement)TestRunnerStatementProvider.getCompatibleTestRunnerStatement(version, new TestRunnerOptions(), getConnection());
+    }
+
     @Test
     void testGettingPre303Version() throws SQLException {
-        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.V3_0_2, new TestRunnerOptions(), getConnection());
+        AbstractTestRunnerStatement stmt = getTestRunnerStatementForVersion(Version.V3_0_2);
         assertEquals(Pre303TestRunnerStatement.class, stmt.getClass());
+        assertThat(stmt.getSql(), not(containsString("a_fail_on_errors")));
+        assertThat(stmt.getSql(), not(containsString("a_client_character_set")));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
     }
 
 
     @Test
     void testGettingPre312Version_from_303() throws SQLException {
-        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.V3_0_3, new TestRunnerOptions(), getConnection());
+        AbstractTestRunnerStatement stmt = getTestRunnerStatementForVersion(Version.V3_0_3);
         assertEquals(Pre312TestRunnerStatement.class, stmt.getClass());
+        assertThat(stmt.getSql(), containsString("a_fail_on_errors"));
+        assertThat(stmt.getSql(), not(containsString("a_client_character_set")));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
     }
 
     @Test
     void testGettingPre312Version_from_311() throws SQLException {
-        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.V3_1_1, new TestRunnerOptions(), getConnection());
-        assertEquals(Pre312TestRunnerStatement.class, stmt.getClass());
+        AbstractTestRunnerStatement stmt = getTestRunnerStatementForVersion(Version.V3_1_1);
+        assertThat(stmt, instanceOf(Pre312TestRunnerStatement.class));
+        assertThat(stmt.getSql(), containsString("a_fail_on_errors"));
+        assertThat(stmt.getSql(), not(containsString("a_client_character_set")));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
     }
 
     @Test
     void testGettingPre317Version_from_312() throws SQLException {
-        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.V3_1_2, new TestRunnerOptions(), getConnection());
-        assertEquals(Pre317TestRunnerStatement.class, stmt.getClass());
+        AbstractTestRunnerStatement stmt = getTestRunnerStatementForVersion(Version.V3_1_2);
+        assertThat(stmt, instanceOf(Pre317TestRunnerStatement.class));
+        assertThat(stmt.getSql(), containsString("a_fail_on_errors"));
+        assertThat(stmt.getSql(), containsString("a_client_character_set"));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
     }
 
     @Test
     void testGettingPre317Version_from_316() throws SQLException {
-        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.V3_1_6, new TestRunnerOptions(), getConnection());
-        assertEquals(Pre317TestRunnerStatement.class, stmt.getClass());
+        AbstractTestRunnerStatement stmt = getTestRunnerStatementForVersion(Version.V3_1_6);
+        assertThat(stmt, instanceOf(Pre317TestRunnerStatement.class));
+        assertThat(stmt.getSql(), containsString("a_fail_on_errors"));
+        assertThat(stmt.getSql(), containsString("a_client_character_set"));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
+        assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
     }
 
     @Test
     void testGettingActualVersion_from_latest() throws SQLException {
-        TestRunnerStatement stmt = TestRunnerStatementProvider.getCompatibleTestRunnerStatement(Version.LATEST, new TestRunnerOptions(), getConnection());
-        assertEquals(ActualTestRunnerStatement.class, stmt.getClass());
+        AbstractTestRunnerStatement stmt = getTestRunnerStatementForVersion(Version.LATEST);
+        assertThat(stmt, instanceOf(ActualTestRunnerStatement.class));
+        assertThat(stmt.getSql(), containsString("a_fail_on_errors"));
+        assertThat(stmt.getSql(), containsString("a_client_character_set"));
+        assertThat(stmt.getSql(), containsString("a_random_test_order"));
+        assertThat(stmt.getSql(), containsString("a_random_test_order_seed"));
     }
 }


### PR DESCRIPTION
Adds new optional feature RANDOM_EXECUTION_ORDER
Also introduces new TestRunnerStatement since 3.1.7 which uses the new TestRunnerOptions `randomTestOrder` and `randomTestOrderSeed`