### PR TITLE
Feature/support for tags

### DIFF
--- a/src/main/java/org/utplsql/api/TestRunner.java
+++ b/src/main/java/org/utplsql/api/TestRunner.java
@@ -16,6 +16,7 @@ import org.utplsql.api.testRunner.TestRunnerStatement;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.*;
 
@@ -126,6 +127,16 @@ public class TestRunner {
     public TestRunner randomTestOrderSeed( Integer seed ) {
         this.options.randomTestOrderSeed = seed;
         if ( seed != null ) this.options.randomTestOrder = true;
+        return this;
+    }
+
+    public TestRunner addTag( String tag ) {
+        this.options.tags.add(tag);
+        return this;
+    }
+
+    public TestRunner addTags(Collection<String> tags) {
+        this.options.tags.addAll(tags);
         return this;
     }
 

--- a/src/main/java/org/utplsql/api/TestRunnerOptions.java
+++ b/src/main/java/org/utplsql/api/TestRunnerOptions.java
@@ -1,10 +1,12 @@
 package org.utplsql.api;
 
-import com.sun.deploy.util.OrderedHashSet;
 import org.utplsql.api.reporter.Reporter;
 
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Holds the various possible options of TestRunner

--- a/src/main/java/org/utplsql/api/TestRunnerOptions.java
+++ b/src/main/java/org/utplsql/api/TestRunnerOptions.java
@@ -1,10 +1,10 @@
 package org.utplsql.api;
 
+import com.sun.deploy.util.OrderedHashSet;
 import org.utplsql.api.reporter.Reporter;
 
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /**
  * Holds the various possible options of TestRunner
@@ -27,4 +27,9 @@ public class TestRunnerOptions {
     public String clientCharacterSet = Charset.defaultCharset().toString();
     public boolean randomTestOrder = false;
     public Integer randomTestOrderSeed;
+    public final Set<String> tags = new LinkedHashSet<>();
+
+    public String getTagsAsString() {
+        return String.join(",", tags);
+    }
 }

--- a/src/main/java/org/utplsql/api/compatibility/OptionalFeatures.java
+++ b/src/main/java/org/utplsql/api/compatibility/OptionalFeatures.java
@@ -12,7 +12,8 @@ public enum OptionalFeatures {
     FRAMEWORK_COMPATIBILITY_CHECK("3.0.3.1266", null),
     CUSTOM_REPORTERS("3.1.0.1849", null),
     CLIENT_CHARACTER_SET("3.1.2.2130", null),
-    RANDOM_EXECUTION_ORDER("3.1.7.2795", null);
+    RANDOM_EXECUTION_ORDER("3.1.7.2795", null),
+    TAGS("3.1.7.3006", null);
 
     private final Version minVersion;
     private final Version maxVersion;

--- a/src/main/java/org/utplsql/api/testRunner/ActualTestRunnerStatement.java
+++ b/src/main/java/org/utplsql/api/testRunner/ActualTestRunnerStatement.java
@@ -39,7 +39,8 @@ class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
                         "a_fail_on_errors         => " + failOnErrors + ", " +
                         "a_client_character_set   => ?, " +
                         "a_random_test_order      => " + randomExecutionOrder + ", " +
-                        "a_random_test_order_seed => ?"+
+                        "a_random_test_order_seed => ?, "+
+                        "a_tags => ?"+
                         "); " +
                         "END;";
     }
@@ -53,6 +54,12 @@ class ActualTestRunnerStatement extends AbstractTestRunnerStatement {
             callableStatement.setNull(++curParamIdx, Types.INTEGER);
         } else {
             callableStatement.setInt(++curParamIdx, options.randomTestOrderSeed);
+        }
+
+        if ( options.tags.size() == 0 ) {
+            callableStatement.setNull(++curParamIdx, Types.VARCHAR);
+        } else {
+            callableStatement.setString(++curParamIdx, options.getTagsAsString());
         }
 
         return curParamIdx;

--- a/src/test/java/org/utplsql/api/EnvironmentVariableUtilTest.java
+++ b/src/test/java/org/utplsql/api/EnvironmentVariableUtilTest.java
@@ -37,7 +37,7 @@ class EnvironmentVariableUtilTest {
     @Test
     void testGetVariableFromDefault() {
 
-        assertEquals("defaultValue", EnvironmentVariableUtil.getEnvValue("RANDOM" + String.valueOf(System.currentTimeMillis()), "defaultValue"));
+        assertEquals("defaultValue", EnvironmentVariableUtil.getEnvValue("RANDOM" + System.currentTimeMillis(), "defaultValue"));
     }
 
 }

--- a/src/test/java/org/utplsql/api/OptionalFeaturesIT.java
+++ b/src/test/java/org/utplsql/api/OptionalFeaturesIT.java
@@ -74,4 +74,15 @@ class OptionalFeaturesIT extends AbstractDatabaseTest {
             assertFalse(available);
         }
     }
+
+    @Test
+    void tags() throws SQLException, InvalidVersionException {
+        boolean available = OptionalFeatures.TAGS.isAvailableFor(getConnection());
+
+        if (getDatabaseVersion().isGreaterOrEqualThan(Version.V3_1_7)) {
+            assertTrue(available);
+        } else {
+            assertFalse(available);
+        }
+    }
 }

--- a/src/test/java/org/utplsql/api/TestRunnerIT.java
+++ b/src/test/java/org/utplsql/api/TestRunnerIT.java
@@ -88,4 +88,11 @@ class TestRunnerIT extends AbstractDatabaseTest {
                 .run(getConnection());
     }
 
+    @Test
+    void runWithTags() throws SQLException {
+        new TestRunner()
+                .addTag("none")
+                .run(getConnection());
+    }
+
 }

--- a/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
+++ b/src/test/java/org/utplsql/api/testRunner/TestRunnerStatementProviderIT.java
@@ -27,6 +27,7 @@ class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
         assertThat(stmt.getSql(), not(containsString("a_client_character_set")));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
+        assertThat(stmt.getSql(), not(containsString("a_tags")));
     }
 
 
@@ -38,6 +39,7 @@ class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
         assertThat(stmt.getSql(), not(containsString("a_client_character_set")));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
+        assertThat(stmt.getSql(), not(containsString("a_tags")));
     }
 
     @Test
@@ -48,6 +50,7 @@ class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
         assertThat(stmt.getSql(), not(containsString("a_client_character_set")));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
+        assertThat(stmt.getSql(), not(containsString("a_tags")));
     }
 
     @Test
@@ -58,6 +61,7 @@ class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
         assertThat(stmt.getSql(), containsString("a_client_character_set"));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
+        assertThat(stmt.getSql(), not(containsString("a_tags")));
     }
 
     @Test
@@ -68,6 +72,7 @@ class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
         assertThat(stmt.getSql(), containsString("a_client_character_set"));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order")));
         assertThat(stmt.getSql(), not(containsString("a_random_test_order_seed")));
+        assertThat(stmt.getSql(), not(containsString("a_tags")));
     }
 
     @Test
@@ -78,5 +83,6 @@ class TestRunnerStatementProviderIT extends AbstractDatabaseTest {
         assertThat(stmt.getSql(), containsString("a_client_character_set"));
         assertThat(stmt.getSql(), containsString("a_random_test_order"));
         assertThat(stmt.getSql(), containsString("a_random_test_order_seed"));
+        assertThat(stmt.getSql(), containsString("a_tags"));
     }
 }


### PR DESCRIPTION
Adds support for tags

`TestRunner` now has methods `addTag( String tag )` and `addTags( Collection<String> )`
Tags are always passed as comma-separated list to `ut_runner`-API

Resolves #85 