### PR TITLE
Use new public jdbc driver available one maven central 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 env:
   global:
@@ -42,6 +42,8 @@ matrix:
     jdk: openjdk11
   - env: UTPLSQL_VERSION="v3.1.7"
     jdk: openjdk12
+  - env: UTPLSQL_VERSION="v3.1.7"
+    jdk: openjdk13
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,20 +8,6 @@ https://maven.apache.org/install.html
 
 *Don't forget to configure your JAVA_HOME environment variable.*
 
-### Oracle Maven Repository
-The library uses OJDBC Driver to connect to the database, it's added as a maven dependency. To be able to download the Oracle dependencies, you need to configure your access to Oracle's Maven Repository:
-Create file `gradle.properties` in the root directory of the repository and place OTN credentials there:
-```properties
-ORACLE_OTN_USER=user@email.com
-ORACLE_OTN_PASSWORD=password
-```
-
-After configuring your access to Oracle's Maven repository, you will be able to successfully build this API by disabling integration tests.
-
-```bash
-./gradlew build -x intTest
-```
-
 ### Local database with utPLSQL and utPLSQL-demo-project
 
 To usefully contribute you'll have to setup a local database with installed [latest utPLSQL v3](https://github.com/utPLSQL/utPLSQL) and [utPLSQL-demo-project](https://github.com/utPLSQL/utPLSQL-demo-project). 
@@ -33,6 +19,11 @@ If you want to run tests against another database you may set `DB_URL`, `DB_USER
 When you have local database set up you can run the complete build including integration tests by executing 
 ```bash
 ./gradlew build
+```
+
+To build the project without local database you may disable integration tests.
+```bash
+./gradlew build -x intTest
 ```
 
 ### Skip the local database part

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ val baseVersion = "3.1.8-SNAPSHOT"
 version = if (tag != null && "^[0-9.]+$".toRegex().matches(tag)) tag else baseVersion
 
 val coverageResourcesVersion = "1.0.1"
-val ojdbcVersion = "12.2.0.1"
-val junitVersion = "5.5.0"
+val ojdbcVersion = "19.3.0.0"
+val junitVersion = "5.5.2"
 
 val deployerJars by configurations.creating
 
@@ -29,14 +29,6 @@ java {
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    maven {
-        url = uri("https://www.oracle.com/content/secure/maven/content")
-        credentials {
-            // you may set this properties using gradle.properties file in the root of the project or in your GRADLE_HOME
-            username = (project.findProperty("ORACLE_OTN_USER") as String?) ?: System.getenv("ORACLE_OTN_USER")
-            password = (project.findProperty("ORACLE_OTN_PASSWORD") as String?) ?: System.getenv("ORACLE_OTN_PASSWORD")
-        }
-    }
     mavenCentral()
     jcenter()
 }
@@ -47,10 +39,10 @@ dependencies {
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation("org.slf4j:slf4j-api:1.7.26")
-    implementation("com.oracle.jdbc:ojdbc8:$ojdbcVersion") {
-        exclude(group = "com.oracle.jdbc")
+    implementation("com.oracle.ojdbc:ojdbc8:$ojdbcVersion") {
+        exclude(group = "com.oracle.ojdbc")
     }
-    implementation("com.oracle.jdbc:orai18n:$ojdbcVersion")
+    implementation("com.oracle.ojdbc:orai18n:$ojdbcVersion")
 
     // Use Jupiter test framework
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")


### PR DESCRIPTION
Oracle published new driver (19.3.0.0) on maven central so no integration with oracle maven is needed anymore. The driver is still compatible with all versions of DB from 11.2 to 19c.