### PR TITLE
Make "Catch Oracle stuck" optional end not enabled by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ env:
     - UTPLSQL_VERSION="v3.1.6"
     - UTPLSQL_VERSION="v3.1.7"
     - UTPLSQL_VERSION="v3.1.8"
+    - UTPLSQL_VERSION="v3.1.9"
+    - UTPLSQL_VERSION="v3.1.10"
     - UTPLSQL_VERSION="develop"
       UTPLSQL_FILE="utPLSQL"
 

--- a/src/main/java/org/utplsql/api/TestRunner.java
+++ b/src/main/java/org/utplsql/api/TestRunner.java
@@ -145,6 +145,11 @@ public class TestRunner {
         return this;
     }
 
+    public TestRunner catchOraStuck( boolean catchOraStuck ) {
+        this.options.catchOraStuck = catchOraStuck;
+        return this;
+    }
+
     public TestRunnerOptions getOptions() { return options; }
 
     private void delayedAddReporters() {
@@ -213,7 +218,7 @@ public class TestRunner {
 
         TestRunnerStatement testRunnerStatement = null;
         try {
-            testRunnerStatement = initStatementWithTimeout(conn);
+            testRunnerStatement = ( options.catchOraStuck ) ? initStatementWithTimeout(conn) : initStatement(conn);
             logger.info("Running tests");
             testRunnerStatement.execute();
             logger.info("Running tests finished.");
@@ -225,6 +230,10 @@ public class TestRunner {
             if (testRunnerStatement != null) testRunnerStatement.close();
             handleException(e);
         }
+    }
+
+    private TestRunnerStatement initStatement( Connection conn ) throws SQLException {
+        return compatibilityProxy.getTestRunnerStatement(options, conn);
     }
 
     private TestRunnerStatement initStatementWithTimeout( Connection conn ) throws OracleCreateStatmenetStuckException, SQLException {

--- a/src/main/java/org/utplsql/api/TestRunnerOptions.java
+++ b/src/main/java/org/utplsql/api/TestRunnerOptions.java
@@ -30,6 +30,7 @@ public class TestRunnerOptions {
     public boolean randomTestOrder = false;
     public Integer randomTestOrderSeed;
     public final Set<String> tags = new LinkedHashSet<>();
+    public boolean catchOraStuck = false;
 
     public String getTagsAsString() {
         return String.join(",", tags);


### PR DESCRIPTION
Reson for this that I have the assumption that catch is too greedy, leading to more abort- and retries than necessary.