### PR TITLE
Switch to use SERVICE_NAME instead of SID for connecting to DB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - DOCKER_CFG=$HOME/.docker
     - DOCKER_REPO="utplsqlv3/oracledb"
     - CACHE_DIR=$HOME/.cache
-    - DB_URL="127.0.0.1:1521:XE"
+    - DB_URL="127.0.0.1:1521/XE"
     - DB_USER=app
     - DB_PASS=app
     - ORACLE_VERSION="11g-r2-xe"


### PR DESCRIPTION
There were ocassionally some builds failing on connection to DB with error 
`ORA-12519: TNS:no appropriate service handler found error`
[Searching the web suggests](https://stackoverflow.com/a/28926797) that it's best to move away from connections using SID and use SERVICE_NAME instead.

