### PR TITLE
Add back HTML coverage resources.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,9 @@
 
         <sonar.organization>utplsql</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+
+        <coverage.html.version>1.0.1</coverage.html.version>
+        <coverage.html.download.dir>${project.build.directory}/coverage-html-download</coverage.html.download.dir>
     </properties>
 
     <licenses>
@@ -117,6 +120,49 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.8.1</version>
+                <executions>
+                    <execution>
+                        <id>download-coverage-html-assets</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://github.com/utPLSQL/utPLSQL-coverage-html/archive/refs/tags/${coverage.html.version}.zip</url>
+                            <outputDirectory>${coverage.html.download.dir}</outputDirectory>
+                            <outputFileName>coverage-html.zip</outputFileName>
+                            <unpack>true</unpack>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-coverage-html-assets</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/CoverageHTMLReporter</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${coverage.html.download.dir}/utPLSQL-coverage-html-${coverage.html.version}/assets</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/scripts/sql/simple/scripts/tests/APP.TEST_PKG_TEST_ME.pkb
+++ b/scripts/sql/simple/scripts/tests/APP.TEST_PKG_TEST_ME.pkb
@@ -122,5 +122,16 @@ CREATE OR REPLACE PACKAGE BODY TEST_PKG_TEST_ME AS
     UT.EXPECT(VEXPECTED).TO_(EQUAL(VACTUAL));
   END;
 
+
+  PROCEDURE TEST_THAT_FAILS IS
+  BEGIN
+    UT.FAIL('Tis test is meant to fail to demonstrate failure');
+  END;
+
+  PROCEDURE TEST_THAT_RAISES_EXCEPTION IS
+    l_num number;
+  BEGIN
+    l_num := 1/0;
+  END;
 END;
 /

--- a/scripts/sql/simple/scripts/tests/APP.TEST_PKG_TEST_ME.pks
+++ b/scripts/sql/simple/scripts/tests/APP.TEST_PKG_TEST_ME.pks
@@ -84,5 +84,10 @@ CREATE OR REPLACE PACKAGE TEST_PKG_TEST_ME AS
   -- %tags(cursor)
   PROCEDURE TEST_PR_TEST_ME_CURSOR;
 
+  -- %test( This is a failing test)
+  PROCEDURE TEST_THAT_FAILS;
+
+  -- %test( This is a test that raises an exception)
+  PROCEDURE TEST_THAT_RAISES_EXCEPTION;
 END;
 /

--- a/src/main/java/org/utplsql/api/ResourceUtil.java
+++ b/src/main/java/org/utplsql/api/ResourceUtil.java
@@ -3,7 +3,6 @@ package org.utplsql.api;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
@@ -28,12 +27,7 @@ public class ResourceUtil {
         try {
             String resourceName = "/" + resourceAsPath;
             Files.createDirectories(targetDirectory);
-            URL resourceUrl = ResourceUtil.class.getResource(resourceName);
-            if (resourceUrl == null) {
-                throw new IOException("Coverage HTML assets not found in classpath: " + resourceName
-                        + ". The JAR was built without bundled coverage HTML reporter assets.");
-            }
-            URI uri = resourceUrl.toURI();
+            URI uri = ResourceUtil.class.getResource(resourceName).toURI();
             Path myPath;
             if (uri.getScheme().equalsIgnoreCase("jar")) {
                 try (FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
@@ -50,7 +44,7 @@ public class ResourceUtil {
     }
 
     private static void copyRecursive(Path from, Path targetDirectory) throws IOException {
-        Files.walkFileTree(from, new SimpleFileVisitor<>() {
+        Files.walkFileTree(from, new SimpleFileVisitor<Path>() {
 
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {

--- a/src/main/java/org/utplsql/api/ResourceUtil.java
+++ b/src/main/java/org/utplsql/api/ResourceUtil.java
@@ -3,6 +3,7 @@ package org.utplsql.api;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
@@ -27,7 +28,12 @@ public class ResourceUtil {
         try {
             String resourceName = "/" + resourceAsPath;
             Files.createDirectories(targetDirectory);
-            URI uri = ResourceUtil.class.getResource(resourceName).toURI();
+            URL resourceUrl = ResourceUtil.class.getResource(resourceName);
+            if (resourceUrl == null) {
+                throw new IOException("Coverage HTML assets not found in classpath: " + resourceName
+                        + ". The JAR was built without bundled coverage HTML reporter assets.");
+            }
+            URI uri = resourceUrl.toURI();
             Path myPath;
             if (uri.getScheme().equalsIgnoreCase("jar")) {
                 try (FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
@@ -44,7 +50,7 @@ public class ResourceUtil {
     }
 
     private static void copyRecursive(Path from, Path targetDirectory) throws IOException {
-        Files.walkFileTree(from, new SimpleFileVisitor<Path>() {
+        Files.walkFileTree(from, new SimpleFileVisitor<>() {
 
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {

--- a/src/test/java/org/utplsql/api/TestRunnerIT.java
+++ b/src/test/java/org/utplsql/api/TestRunnerIT.java
@@ -1,6 +1,5 @@
 package org.utplsql.api;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.utplsql.api.compatibility.CompatibilityProxy;
@@ -65,7 +64,6 @@ class TestRunnerIT extends AbstractDatabaseTest {
     /**
      * This can only be tested on frameworks >= 3.0.3
      */
-    @Disabled
     @Test
     void failOnErrors() throws SQLException, InvalidVersionException {
         Connection conn = getConnection();
@@ -82,8 +80,6 @@ class TestRunnerIT extends AbstractDatabaseTest {
 
     @Test
     void runWithRandomExecutionOrder() throws SQLException {
-        CompatibilityProxy proxy = new CompatibilityProxy(getConnection());
-
         new TestRunner()
                 .randomTestOrder(true)
                 .randomTestOrderSeed(123)

--- a/src/test/java/org/utplsql/api/reporter/CoverageHTMLReporterAssetTest.java
+++ b/src/test/java/org/utplsql/api/reporter/CoverageHTMLReporterAssetTest.java
@@ -1,6 +1,5 @@
 package org.utplsql.api.reporter;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -25,7 +24,6 @@ class CoverageHTMLReporterAssetTest {
         assertTrue(f.exists(), () -> "File " + f + " does not exist");
     }
 
-    @Disabled("No idea why this ever worked")
     @Test
     void writeReporterAssetsTo() throws RuntimeException {
 


### PR DESCRIPTION
The HTML coverage resources were missing since version 3.1.9 of the utplsql-java-api.

They are now again included in the JAR so that the utplsql-maven-plugin and utPLSQL-cli can use it.